### PR TITLE
glance:// protocol for authenticated gcloud datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 credentials.tar.gz
 client-secret.json
 /node_modules/
@@ -8,3 +9,6 @@ client-secret.json
 *.pyc
 __pycache__
 *.sw[pmn]
+env
+venv
+static

--- a/devserver.sh
+++ b/devserver.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Same as travis deploy script
+
+# npm install
+npm run build
+rm -r static/
+mkdir static/
+cp -r ./dist/dev/* static/
+virtualenv env
+source env/bin/activate
+pip install -t lib -r requirements.txt
+dev_appserver.py app.yaml

--- a/src/neuroglancer/util/http_request.spec.ts
+++ b/src/neuroglancer/util/http_request.spec.ts
@@ -1,0 +1,22 @@
+import {parseSpecialUrl} from 'neuroglancer/util/http_request';
+
+describe('Prasing Special URLs', () => {
+  let ezParseSpecialUrl = (url: string) => parseSpecialUrl(url)[0][0];
+
+  it('Parse Normal URL', () => {
+    expect(ezParseSpecialUrl('http://example.com/arg1/arg2/arg3/')).toBe('http://example.com/arg1/arg2/arg3/');
+    expect(ezParseSpecialUrl('https://example.com/arg1/arg2/arg3/')).toBe('https://example.com/arg1/arg2/arg3/');
+    expect(ezParseSpecialUrl('ftp://example.com/arg1/arg2/arg3/')).toBe('ftp://example.com/arg1/arg2/arg3/');
+  });
+
+  it('Parse Google Storage Url (gs://)', () => {
+    let result = parseSpecialUrl('gs://bucket/dataset/layer/')
+    
+    expect(result[0][0]).toBe('https://storage.googleapis.com/bucket');
+    expect(result[1]).toBe('/dataset/layer/');
+  });
+
+  it('Parse Glance Url (glance://)', () => {
+    expect(ezParseSpecialUrl('glance://dataset/layer/')).toBe('https://localhost/blob/dataset/layer/');
+  });
+});

--- a/src/neuroglancer/util/http_request.ts
+++ b/src/neuroglancer/util/http_request.ts
@@ -118,5 +118,10 @@ export function parseSpecialUrl(url: string): [string[], string] {
     ];
     return [baseUrls, match[3]];
   }
+  else if (protocol === 'glance') {
+    const gs_cloudpath = url.replace('glance://', '');
+    url = `https://${location.hostname}/blob/${gs_cloudpath}`;
+  }
+
   return [[url], ''];
 }


### PR DESCRIPTION
Allow people to use glance://golden_v0/image instead of https://example.com/blob/golden_v0/image when specifying datasets

Also created Google app engine devserver start script