### PR TITLE
Support non-grid-aligned slices

### DIFF
--- a/python/neuroglancer/ingest/tasks.py
+++ b/python/neuroglancer/ingest/tasks.py
@@ -307,9 +307,8 @@ class MeshTask(object):
     def _download_input_chunk(self):
         """
         It assumes that the chunk_position includes a 1 pixel overlap
-        FIXME choose the mip level based on the chunk key
         """
-        #TODO modify Precomputed to allow for non-grid aligned tasks
+        #FIXME choose the mip level based on the chunk key
         volume = Precomputed(self._storage)
         self._data = volume[self._xmin:self._xmax,
                             self._ymin:self._ymax,

--- a/python/neuroglancer/ingest/volumes/precomputed.py
+++ b/python/neuroglancer/ingest/volumes/precomputed.py
@@ -23,16 +23,15 @@ class Precomputed(object):
         self.info = json.loads(self._storage.get_file('info'))
 
     def __getitem__(self, slices):
+        """ It allows for non grid aligned slices
         """
-        It only supports grid aligned slices which
-        spans an intenger number of chunks.
-        """
+        new_slices, sub_slices = self._align_slices(slices)
         return_volume = np.empty(
-            shape=self._get_slices_shape(slices),
+            shape=self._get_slices_shape(new_slices),
             dtype=self.info['data_type'])
 
-        offset =  self._get_offsets(slices)
-        for c in self._iter_chunks(slices):
+        offset =  self._get_offsets(new_slices)
+        for c in self._iter_chunks(new_slices):
 
             file_path = self._chunk_to_file_path(c)
             content = chunks.decode(
@@ -41,9 +40,14 @@ class Precomputed(object):
                 shape=self._get_chunk_shape(c),
                 dtype=self.info['data_type'])
             return_volume[self._slices_from_chunk(c,offset)] = content
-        return return_volume
+        return return_volume[sub_slices]
 
     def __setitem__(self, slices, input_volume):
+        """
+        It purposely doesn't allow for non grid aligned slices.
+        That is because the result of two workers writting
+        to overlapping chunks would be hard to predict.
+        """
         offset =  self._get_offsets(slices)
         for c in self._iter_chunks(slices):
             content = chunks.encode(
@@ -92,6 +96,29 @@ class Precomputed(object):
                                      y_start, y_stop,
                                      z_start, z_stop)
 
+    def _align_slices(self, slices):
+        """
+        Return new_slices, sub_slices with the property that
+        new_slices is grid aligned and A[new_slices][sub_slices]
+        is equal to A[slices]
+        """
+        new_slices=[]
+        sub_slices=[]
+        for slc_idx in xrange(len(slices)):
+            slc = slices[slc_idx]
+            voxel_offset = self._scale['voxel_offset'][slc_idx]
+            start = slc.start - voxel_offset
+            stop = slc.stop - voxel_offset
+            chunk_size = self._scale['chunk_sizes'][0][slc_idx]
+
+            #round to nearest grid size
+            new_start = start - (start % chunk_size)
+            new_stop = stop + ((-stop) % chunk_size)
+
+            new_slices.append(slice(new_start + voxel_offset, new_stop + voxel_offset))
+            sub_slices.append(slice(start % chunk_size, stop - new_start))
+
+        return tuple(new_slices), tuple(sub_slices)
 
     def _slice_to_chunks(self, slices, slc_idx):
         slc = slices[slc_idx]

--- a/python/test/test_precomputed.py
+++ b/python/test/test_precomputed.py
@@ -26,7 +26,7 @@ def create_layer(size, offset, layer_type="image"):
 def delete_layer():
     shutil.rmtree("/tmp/removeme/layer", ignore_errors=True)
     
-def test_read():
+def test_aligned_read():
     delete_layer()
     storage, data = create_layer(size=(50,50,50,1), offset=(0,0,0))
     pr = Precomputed(storage)
@@ -40,7 +40,7 @@ def test_read():
     #the last dimension is the number of channels
     assert pr[0:64,0:64,0:64].shape == (64,64,64,1) 
     assert np.all(pr[0:64,0:64,0:64] ==  data[:64,:64,:64,:])
-    
+
     delete_layer()
     storage, data = create_layer(size=(128,64,64,1), offset=(10,20,0))
     pr = Precomputed(storage)
@@ -52,6 +52,22 @@ def test_read():
     cutout2 = pr[74:138,20:84,0:64]
     assert cutout2.shape == (64,64,64,1) 
     assert np.all(cutout2 ==  data[64:128,:64,:64,:])
+
+def test_non_aligned_read():
+    delete_layer()
+    storage, data = create_layer(size=(128,64,64,1), offset=(0,0,0))
+    pr = Precomputed(storage)
+    #the last dimension is the number of channels
+    assert pr[31:65,0:64,0:64].shape == (34,64,64,1) 
+    assert np.all(pr[31:65,0:64,0:64] ==  data[31:65,:64,:64,:])
+
+    #read a single pixel
+    delete_layer()
+    storage, data = create_layer(size=(64,64,64,1), offset=(0,0,0))
+    pr = Precomputed(storage)
+    #the last dimension is the number of channels
+    assert pr[22:23,22:23,22:23].shape == (1,1,1,1) 
+    assert np.all(pr[22:23,22:23,22:23] ==  data[22:23,22:23,22:23,:])
 
 def test_write():
     delete_layer()


### PR DESCRIPTION
Precomputed now allows for non grid aligned slices read, which is
required for MeshTask to get the 1-pixel overlap.
Maybe we should add a flag to the constructor to dissable this
feature, given that if by mistake we get non-aligned there is
a big performance penalty.

Writting to non grid aligned slices is dissable, because task
processing should be idempotent. And we have no methods for
write sincronization between tasks.