### PR TITLE
fix(precomputed): __setitem__ didn't check shape size.

### DIFF
--- a/python/neuroglancer/pipeline/precomputed.py
+++ b/python/neuroglancer/pipeline/precomputed.py
@@ -50,9 +50,12 @@ class Precomputed(object):
         """
         offset =  self._get_offsets(slices)
         for c in self._iter_chunks(slices):
-            content = chunks.encode(
-                input_volume[self._slices_from_chunk(c, offset)], 
-                self._scale['encoding'])
+            input_chunk = input_volume[self._slices_from_chunk(c, offset)]
+            if input_chunk.shape != self._get_chunk_shape(c):
+                raise ValueError("Illegal slicing, {} != {}".format(
+                    self._get_slices_shape(slices), input_volume.shape))
+
+            content = chunks.encode(input_chunk, self._scale['encoding'])
             self._storage.put_file(
                 file_path=self._chunk_to_file_path(c),
                 content=content)

--- a/python/test/test_precomputed.py
+++ b/python/test/test_precomputed.py
@@ -156,3 +156,11 @@ def test_reader_grid_aligned():
 
     with pytest.raises(ValueError):
         pr._slice_to_chunks([slice(63,128)], slc_idx=0)
+
+
+def test_setitem_mismatch():
+    delete_layer()
+    storage, data = create_layer(size=(64,64,64,1), offset=(0,0,0))
+    pr = Precomputed(storage)
+    with pytest.raises(ValueError):
+        pr[0:64,0:64,0:64] = np.zeros(shape=(5,5,5,1), dtype=np.uint8)


### PR DESCRIPTION
`pr[0:64,0:64,0:64] = np.zeros(shape=(5,5,5,1))`
used to be legal because we were not checking sizes.

Numpy advance slicing was letting this happen:
```
In [1]: import numpy as np

In [2]: np.zeros(shape=(2,))[0:4]
Out[2]: array([ 0.,  0.])
```

This was causing corrupt chunks, which were not able
to be visualize in neuroglancer.