### PR TITLE
TaskQueue Purge Fix + TaskQueue.get Support

### DIFF
--- a/python/neuroglancer/pipeline/secrets.py
+++ b/python/neuroglancer/pipeline/secrets.py
@@ -1,8 +1,9 @@
+import os
 import json
 
 from oauth2client import service_account
 
-QUEUE_NAME = 'pull-queue'
+QUEUE_NAME = 'pull-queue' if 'PIPELINE_USER_QUEUE' not in os.environ else os.environ['PIPELINE_USER_QUEUE']
 PROJECT_NAME = 'neuromancer-seung-import'
 
 google_credentials_path = '/secrets/google-secret.json'

--- a/python/test/test_taskqueue.py
+++ b/python/test/test_taskqueue.py
@@ -4,10 +4,16 @@ import pytest
 
 from neuroglancer.pipeline.tasks import RegisteredTask
 from neuroglancer.pipeline import TaskQueue
+from neuroglancer.pipeline.secrets import PROJECT_NAME
 
+import time
+
+PIPELINE_USER_QUEUE = None if 'PIPELINE_USER_QUEUE' not in os.environ else os.environ['PIPELINE_USER_QUEUE']
 TRAVIS_BRANCH = None if 'TRAVIS_BRANCH' not in os.environ else os.environ['TRAVIS_BRANCH']
 
-if TRAVIS_BRANCH is None:
+if PIPELINE_USER_QUEUE is not None:
+  QUEUE_NAME = PIPELINE_USER_QUEUE
+elif TRAVIS_BRANCH is None:
   QUEUE_NAME = 'test-pull-queue'
 elif TRAVIS_BRANCH == 'master':
   QUEUE_NAME = 'travis-pull-queue-1'
@@ -18,13 +24,34 @@ class MockTask(RegisteredTask):
   def __init__(self):
     super(MockTask, self).__init__()
 
-def test_single_threaded_insertion():
+def test_get():
   global QUEUE_NAME
   tq = TaskQueue(n_threads=0, queue_name=QUEUE_NAME)
 
   n_inserts = 5
-
   tq.purge()
+
+  try:
+    for _ in xrange(n_inserts):
+      task = MockTask()
+      tq.insert(task)
+    tq.wait()
+
+    tqinfo = tq.get()
+    assert tqinfo['id'] == 'projects/s~{}/taskqueues/{}'.format(PROJECT_NAME, QUEUE_NAME)
+    assert tqinfo['stats']['totalTasks'] == n_inserts
+    assert tq.enqueued == n_inserts
+  finally:
+    tq.purge()
+
+  time.sleep(5)
+  assert tq.enqueued == 0
+
+def test_single_threaded_insertion():
+  global QUEUE_NAME
+  tq = TaskQueue(n_threads=0, queue_name=QUEUE_NAME).purge()
+  
+  n_inserts = 5
 
   try:
     for _ in xrange(n_inserts):
@@ -32,34 +59,36 @@ def test_single_threaded_insertion():
       tq.insert(task)
 
     lst = tq.list()
-
     assert lst.has_key('items')
 
     items = lst['items']
-
     assert len(items) == n_inserts
 
     tags = map(lambda x: x['tag'], items)
-
     assert all(map(lambda x: x == MockTask.__name__, tags))
   finally:
     tq.purge()
 
+  lst = tq.list()
+  assert not lst.has_key('items')
 
 def test_multi_threaded_insertion():
   global QUEUE_NAME
   tq = TaskQueue(n_threads=40, queue_name=QUEUE_NAME)
 
-  n_inserts = 100
+  n_inserts = 1000
 
   tq.purge()
+
+  time.sleep(1)
+  assert tq.enqueued == 0
 
   try:
     for _ in xrange(n_inserts):
       task = MockTask()
       tq.insert(task)
 
-    tq.wait_until_queue_empty()
+    tq.wait()
 
     lst = tq.list()
 
@@ -67,13 +96,18 @@ def test_multi_threaded_insertion():
 
     items = lst['items']
 
-    assert len(items) == n_inserts
+    assert len(items) == 100 # task list api only lists 100 items at a time
+    # time.sleep(5)
+    # assert tq.enqueued == n_inserts # Google is returning impossible values like 1005
 
     tags = map(lambda x: x['tag'], items)
 
     assert all(map(lambda x: x == MockTask.__name__, tags))
   finally:
     tq.purge()
+
+  time.sleep(5)
+  assert tq.enqueued == 0
   
 
 


### PR DESCRIPTION
- TaskQueue.purge was relisting while threads were still deleting the last listing.
This leads to weird race conditions that is fixed with a simple wait.
- Added TaskQueue.wait as it allows for nice semantics like tq.delete().wait()
- Added support for TaskQueue.get, TaskQueue.get_task, and TaskQueue.enqueued

Note: Failing downsample test is fixed in PR #43 which is caused by a race condition.