### PR TITLE
refractor(storage): wait_until_queue_empty -> wait

### DIFF
--- a/python/neuroglancer/pipeline/precomputed.py
+++ b/python/neuroglancer/pipeline/precomputed.py
@@ -72,10 +72,9 @@ class Precomputed(object):
         return_volume = np.empty(
             shape=self._get_slices_shape(aligned_slices),
             dtype=self.info['data_type'])
-
+        
         offset =  self._get_offsets(aligned_slices)
         for c in self._iter_chunks(aligned_slices):
-
             file_path = self._chunk_to_file_path(c)
             content =  self._storage.get_file(file_path)
             if not content and not self._fill:
@@ -106,6 +105,7 @@ class Precomputed(object):
             self._storage.put_file(
                 file_path=self._chunk_to_file_path(c),
                 content=content)
+        self._storage.wait()
 
     def _get_offsets(self, slices):
         first_chunk = self._iter_chunks(slices).next()

--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -58,7 +58,7 @@ class Storage(object):
             worker.start()
 
     def _kill_threads(self):
-        self.wait_until_queue_empty()
+        self.wait()
         for _ in xrange(self._n_threads):
             self._queue.put( ('TERMINATE', None, None ) )
 
@@ -160,8 +160,7 @@ class Storage(object):
 
                 store_result(path, result, error)
 
-        self.wait_until_queue_empty()
-
+        self.wait()
         return results
 
     def _maybe_uncompress(self, content):
@@ -193,11 +192,12 @@ class Storage(object):
         for f in self._interface(self._path).list_files(prefix):
             yield f
 
-    def wait_until_queue_empty(self):
+    def wait(self):
         if self._n_threads:
             self._queue.join()
-
-    def __del__(self):
+        return self
+    
+    def __del__(self):      
         self._kill_threads()
 
 class FileInterface(object):
@@ -229,9 +229,6 @@ class FileInterface(object):
                 os.makedirs(os.path.dirname(path))
             except OSError:
                 pass
-
-            with open(path, 'wb') as f:
-                f.write(content)
 
     def get_file(self, file_path):
         path = self.get_path_to_file(file_path) 

--- a/python/neuroglancer/pipeline/task_creation.py
+++ b/python/neuroglancer/pipeline/task_creation.py
@@ -233,6 +233,9 @@ class MockTaskQueue():
         task.execute()
         del task
 
+    def wait(self):
+        return self
+
 
 def ingest_hdf5_example():
     dataset_path='gs://neuroglancer/test_v0'

--- a/python/test/test_storage.py
+++ b/python/test/test_storage.py
@@ -1,6 +1,7 @@
 import pytest
 import re
 import shutil
+import time
 
 from neuroglancer.pipeline import Storage
 
@@ -39,7 +40,7 @@ def test_read_write():
             s = Storage(url, n_threads=num_threads)
             content = 'some_string'
             s.put_file('info', content, compress=False)
-            s.wait_until_queue_empty()
+            s.wait()
             assert s.get_file('info') == content
             assert s.get_file('nonexistentfile') is None
 
@@ -64,7 +65,7 @@ def test_compression():
         s = Storage(url, n_threads=5)
         content = 'some_string'
         s.put_file('info', content, compress=True)
-        s.wait_until_queue_empty()
+        s.wait()
         assert s.get_file('info') == content
         assert s.get_file('nonexistentfile') is None
 
@@ -78,10 +79,11 @@ def test_list():
     for url in urls:
         s = Storage(url, n_threads=5)
         content = 'some_string'
-        s.put_file('info1', content , compress=False)
-        s.put_file('info2', content , compress=False)
-        s.put_file('build/info3', content , compress=False)
-        s.wait_until_queue_empty()
+        s.put_file('info1', content, compress=False)
+        s.put_file('info2', content, compress=False)
+        s.put_file('build/info3', content, compress=False)
+        s.wait()
+        time.sleep(1) # sometimes it takes a moment for google to update the list
         assert set(s.list_files(prefix='')) == set(['info1','info2'])
         assert set(s.list_files(prefix='inf')) == set(['info1','info2'])
         assert set(s.list_files(prefix='info1')) == set(['info1'])

--- a/python/test/test_tasks.py
+++ b/python/test/test_tasks.py
@@ -14,7 +14,7 @@ def test_downsample():
     assert len(pr.info['scales']) == 1
     create_downsampling_task(storage, MockTaskQueue(), downsample_ratio=[2, 2, 1])
     # pr.info now has an outdated copy of the info file
-    storage.wait_until_queue_empty()
+    storage.wait()
     pr_new = Precomputed(storage, scale_idx=1)
     assert len(pr_new.info['scales']) == 2
     assert pr_new.info['scales'][1]['size'] == [64,64,64]


### PR DESCRIPTION
refractor(tasks): wait_until_queue_empty -> wait
To speed up file uploading and downloading Storage implements
asyncronous operations. When subsequent code depends on the
operations being performed wait() is required. wait() blocks
until all operations have being executed.

It renames wait_until_queue_empty() to the less verbose wait()
in the Storage class.

This commit also adds wait() to task which required it and were
neglecting it.