### PR TITLE
Add content_type to put_files and gzip support to Fileinterface

### DIFF
--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -253,6 +253,8 @@ class FileInterface(object):
         path = self.get_path_to_file(file_path)
         if os.path.exists(path):
             os.remove(path)
+        elif os.path.exists(path + '.gz'):
+            os.remove(path + '.gz')
 
     def list_files(self, prefix, flat):
         """
@@ -380,7 +382,9 @@ class S3Interface(object):
                     "Content-Encoding": "gzip",
                 })
         else:
-            k.set_contents_from_string(content)
+            k.set_contents_from_string(content, headers={
+                "Content-Type": content_type or 'application/octet-stream',
+            })
             
     def get_file(self, file_path):
         """

--- a/python/test/test_storage.py
+++ b/python/test/test_storage.py
@@ -100,11 +100,13 @@ def test_list():
             s.put_file('info2', content, compress=False)
             s.put_file('build/info3', content, compress=False)
             s.put_file('level1/level2/info4', content, compress=False)
+            s.put_file('info5', content, compress=True)
+            s.put_file('info.txt', content, compress=False)
             s.wait()
             time.sleep(1) # sometimes it takes a moment for google to update the list
-            assert set(s.list_files(prefix='')) == set(['build/info3','info1', 'info2', 'level1/level2/info4'])
+            assert set(s.list_files(prefix='')) == set(['build/info3','info1', 'info2', 'level1/level2/info4', 'info5', 'info.txt'])
             
-            assert set(s.list_files(prefix='inf')) == set(['info1','info2'])
+            assert set(s.list_files(prefix='inf')) == set(['info1','info2','info5','info.txt'])
             assert set(s.list_files(prefix='info1')) == set(['info1'])
             assert set(s.list_files(prefix='build')) == set(['build/info3'])
             assert set(s.list_files(prefix='build/')) == set(['build/info3'])
@@ -112,8 +114,8 @@ def test_list():
             assert set(s.list_files(prefix='nofolder/')) == set([])
 
             # Tests (1)
-            assert set(s.list_files(prefix='', flat=True)) == set(['info1','info2'])
-            assert set(s.list_files(prefix='inf', flat=True)) == set(['info1','info2'])
+            assert set(s.list_files(prefix='', flat=True)) == set(['info1','info2','info5','info.txt'])
+            assert set(s.list_files(prefix='inf', flat=True)) == set(['info1','info2','info5','info.txt'])
             # Tests (2)
             assert set(s.list_files(prefix='build', flat=True)) == set([])
             # Tests (3)
@@ -122,7 +124,7 @@ def test_list():
             # Tests (4)
             assert set(s.list_files(prefix='build/inf', flat=True)) == set(['build/info3'])
 
-            for file_path in ('info1', 'info2', 'build/info3', 'level1/level2/info4'):
+            for file_path in ('info1', 'info2', 'build/info3', 'level1/level2/info4', 'info5', 'info.txt'):
                 s.delete_file(file_path)
     
     shutil.rmtree("/tmp/removeme/list")

--- a/python/test/test_storage.py
+++ b/python/test/test_storage.py
@@ -57,17 +57,24 @@ def test_read_write():
     shutil.rmtree("/tmp/removeme/read_write")
 
 def test_delete():
-    urls = ["file:///tmp/removeme/list",
-            "gs://neuroglancer/removeme/list",
-            "s3://neuroglancer/removeme/list"]
+    urls = [
+        "file:///tmp/removeme/delete",
+        "gs://neuroglancer/removeme/delete",
+        "s3://neuroglancer/removeme/delete"
+    ]
 
     for url in urls:
         with Storage(url, n_threads=1) as s:
             content = 'some_string'
             s.put_file('delete-test', content, compress=False).wait()
+            s.put_file('delete-test-compressed', content, compress=True).wait()
             assert s.get_file('delete-test') == content
             s.delete_file('delete-test').wait()
             assert s.get_file('delete-test') is None
+
+            assert s.get_file('delete-test-compressed') == content
+            s.delete_file('delete-test-compressed').wait()
+            assert s.get_file('delete-test-compressed') is None
 
 def test_compression():
     urls = ["file:///tmp/removeme/compression",


### PR DESCRIPTION
- Adds content_type to storage.put_file and storage.put_files
- Adds gzip support to FileInterface for storage. 

Previously, threads would often collide when executing
os.makedirs in the FileInterface. This made testing unreliable
as random failures could happen. This is fixed by handling
errors properly in lib.mkdir, which is now threadsafe and
accessible to all pipeline files. This replaces the locking
system that bottlenecks multithreaded processes.

Additionally, we've added support for setting the Content-Type
of put files.

Additionally, the FileInterface now supports compressed files
correctly allowing for uniform testing and transparent compressed
file storage.