### PR TITLE
fix(GoogleCloudStorageInterface): downloads gzipped if available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y -qq --no-install-recommends \
     apt-utils \
     curl \
+    git \
     openssh-client \
     python-openssl \
     python \

--- a/python/neuroglancer/pipeline/precomputed.py
+++ b/python/neuroglancer/pipeline/precomputed.py
@@ -80,12 +80,12 @@ class Precomputed(object):
             if not content and not self._fill:
                 raise EmptyVolumeException()
 
-            content = chunks.decode(
-                self._storage.get_file(file_path), 
+            decoded = chunks.decode(
+                filedata=content,
                 encoding=self._scale['encoding'], 
                 shape=self._get_chunk_shape(c),
                 dtype=self.info['data_type'])
-            return_volume[self._slices_from_chunk(c,offset)] = content
+            return_volume[self._slices_from_chunk(c,offset)] = decoded
         return return_volume[crop_slices]
 
     def __setitem__(self, slices, input_volume):
@@ -101,10 +101,10 @@ class Precomputed(object):
                 raise ValueError("Illegal slicing, {} != {}".format(
                     self._get_slices_shape(slices), input_volume.shape))
 
-            content = chunks.encode(input_chunk, self._scale['encoding'])
+            encoded = chunks.encode(input_chunk, self._scale['encoding'])
             self._storage.put_file(
                 file_path=self._chunk_to_file_path(c),
-                content=content)
+                content=encoded)
         self._storage.wait()
 
     def _get_offsets(self, slices):

--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -228,7 +228,7 @@ class FileInterface(object):
             f.write(content)
 
     def get_file(self, file_path):
-        path = self.get_path_to_file(file_path) 
+        path = self.get_path_to_file(file_path)
         try:
             with open(path, 'rb') as f:
                 return f.read(), None
@@ -278,7 +278,9 @@ class GoogleCloudStorageInterface(object):
         blob = self._bucket.get_blob( key )
         if not blob:
             return None, False
-        return blob.download_as_string(), blob.content_encoding == "gzip"
+        # blob handles the decompression in the case
+        # it is necessary
+        return blob.download_as_string(), False
 
     def list_files(self, prefix):
         """

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,7 +9,6 @@ Cython==0.25.2
 certifi==2016.9.26
 decorator==4.0.11
 google-api-python-client==1.6.2
-google-cloud==0.22.0
 networkx==1.11
 numpy==1.11.1
 pytest==3.0.7 
@@ -23,3 +22,8 @@ tqdm==4.7.6
 tornado==4.4.2
 wsgiref==0.1.2
 scipy==0.18.1
+
+# do not use
+# google-cloud==0.22.0 
+# use hacked version which adds accept-encoding
+git+git://github.com/tartavull/google-cloud-python@hack#egg=google-cloud


### PR DESCRIPTION
The python library google-cloud doesn't set the header
`accept-encoding` when retriving objects from google
cloud storage.
The server decompresses the gzipped objects and send
them to the client. Making transfers way larger than
what they should be. For example for a segmentation which
has a size of 64mb is around 500kb compressed.

The library was forked in
https://github.com/tartavull/google-cloud-python
and modified to set the correct headers, and the
requirements file modified to use it. Solving:
https://github.com/seung-lab/neuroglancer/issues/65

Another bug was fixed, were objects were download twice.