### PR TITLE
refactor: moved test layer creation/deletion to layer_harness

### DIFF
--- a/python/test/layer_harness.py
+++ b/python/test/layer_harness.py
@@ -1,0 +1,45 @@
+import pytest
+
+import shutil
+import numpy as np
+
+import os
+
+from neuroglancer.pipeline.storage import Storage
+from neuroglancer.pipeline.task_creation import (upload_build_chunks, create_info_file_from_build,
+    create_ingest_task, MockTaskQueue)
+
+layer_path = '/tmp/removeme/'
+
+def create_storage(layer_name='layer'):
+    uri = 'file://' + os.path.join(layer_path, layer_name)
+    return Storage(uri, n_threads=0)
+
+def create_layer(size, offset=[0,0,0], layer_type="image", layer_name="layer"):
+    storage = create_storage(layer_name)
+
+    if layer_type == "image":
+        random_data = np.random.randint(255, size=size, dtype=np.uint8)
+        upload_build_chunks(storage, random_data, offset)
+        # Jpeg encoding is lossy so it won't work
+        create_info_file_from_build(storage, layer_type= 'image', encoding="raw", force_chunk=[64,64,64])
+    elif layer_type == "affinities":
+        random_data = np.random.uniform(size=size).astype(np.float32)
+        upload_build_chunks(storage, random_data, offset)
+        create_info_file_from_build(storage, layer_type= 'image', encoding="raw", force_chunk=[64,64,64])
+    elif layer_type == "segmentation":
+        random_data = np.random.randint(0xFFFFFF, size=size, dtype=np.uint32)
+        upload_build_chunks(storage, random_data, offset)
+        # Jpeg encoding is lossy so it won't work
+        create_info_file_from_build(storage, layer_type= 'segmentation', encoding="raw", force_chunk=[64,64,64])
+    create_ingest_task(storage, MockTaskQueue())
+    return storage, random_data
+    
+def delete_layer(layer_name="layer"):
+    path = os.path.join(layer_path, layer_name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+    
+    
+    

--- a/python/test/test_precomputed.py
+++ b/python/test/test_precomputed.py
@@ -6,30 +6,8 @@ import numpy as np
 from neuroglancer.pipeline import Storage, Precomputed
 from neuroglancer.pipeline.task_creation import (upload_build_chunks, create_info_file_from_build,
     create_ingest_task, MockTaskQueue)
+from test.layer_harness import delete_layer, create_layer
 
-def create_layer(size, offset=[0,0,0], layer_type="image", layer_name="layer"):
-    storage = Storage('file:///tmp/removeme/'+ layer_name, n_threads=0)
-
-    if layer_type == "image":
-        random_data = np.random.randint(255, size=size, dtype=np.uint8)
-        upload_build_chunks(storage, random_data, offset)
-        # Jpeg encoding is lossy so it won't work
-        create_info_file_from_build(storage, layer_type= 'image', encoding="raw", force_chunk=[64,64,64])
-    elif layer_type == "affinities":
-        random_data = np.random.uniform(size=size).astype(np.float32)
-        upload_build_chunks(storage, random_data, offset)
-        create_info_file_from_build(storage, layer_type= 'image', encoding="raw", force_chunk=[64,64,64])
-    elif layer_type == "segmentation":
-        random_data = np.random.randint(0xFFFFFF, size=size, dtype=np.uint32)
-        upload_build_chunks(storage, random_data, offset)
-        # Jpeg encoding is lossy so it won't work
-        create_info_file_from_build(storage, layer_type= 'segmentation', encoding="raw", force_chunk=[64,64,64])
-    create_ingest_task(storage, MockTaskQueue())
-    return storage, random_data
-
-def delete_layer(layer_name="layer"):
-    shutil.rmtree("/tmp/removeme/"+layer_name, ignore_errors=True)
-    
 def test_aligned_read():
     delete_layer()
     storage, data = create_layer(size=(50,50,50,1), offset=(0,0,0))

--- a/python/test/test_tasks.py
+++ b/python/test/test_tasks.py
@@ -5,7 +5,7 @@ import numpy as np
 from neuroglancer.pipeline import Storage, Precomputed, DownsampleTask, MeshTask, WatershedTask
 from neuroglancer.pipeline.task_creation import create_downsampling_task, MockTaskQueue
 from neuroglancer import downsample
-from test.test_precomputed import create_layer, delete_layer
+from test.layer_harness import create_layer, delete_layer
 
 def test_downsample_segmentation():
     delete_layer()


### PR DESCRIPTION
Moved from precomputed so that testing code can live in its own
space.

Also changed layer_delete to not ignore errors.

Added function create_storage in anticipation of additional tests being added.

**Testing Sufficiency Declaration**
Tests continue to pass.