### PR TITLE
Tasks could not be leased

### DIFF
--- a/python/neuroglancer/pipeline/task_queue.py
+++ b/python/neuroglancer/pipeline/task_queue.py
@@ -203,18 +203,19 @@ class TaskQueue(ThreadedQueue):
         """
         raise NotImplemented
 
-    def lease(self, tag=''):
+    def lease(self, tag=None):
         """
         Acquires a lease on the topmost N unowned tasks in the specified queue.
         Required query parameters: leaseSecs, numTasks
         """
+        tag = tag if tag else None
         
         tasks = self._api.tasks().lease(
             project=self._project,
             taskqueue=self._queue_name, 
             numTasks=1, 
             leaseSecs=600,
-            groupByTag=(tag != ''),
+            groupByTag=(tag is not None),
             tag=tag,
         ).execute(num_retries=6)
 


### PR DESCRIPTION
When tag was set to '', it still activated that part of the API,
which then tried to group tasks by the empty tag.