### PR TITLE
feat(downsample): added max pooling

### DIFF
--- a/python/neuroglancer/downsample.py
+++ b/python/neuroglancer/downsample.py
@@ -33,8 +33,9 @@ def validate_factor(array, factor):
   if np.any(factor <= 0):
     raise ValueError("Factors less than one don't make sense. Factor: {}".format(factor))
 
-  if len(array.shape) == 4 and len(factor) == 3:
-    factor = list(factor) + [ 1 ] # don't mix channels
+  factor = list(factor)
+  while len(factor) < len(array.shape):
+    factor += [ 1 ]
 
   return tuple(factor)
 

--- a/python/neuroglancer/downsample.py
+++ b/python/neuroglancer/downsample.py
@@ -87,7 +87,11 @@ def scale_series_to_downsample_factors(scales):
   return [ factor.astype(int) for factor in factors ]
 
 def downsample_with_averaging(array, factor):
-    """Downsample x by factor using averaging.
+    """
+    Downsample x by factor using averaging.
+
+    If factor has fewer parameters than data.shape, the remainder
+    are assumed to be 1.
 
     @return: The downsampled array, of the same type as x.
     """
@@ -106,6 +110,13 @@ def downsample_with_averaging(array, factor):
     return np.cast[array.dtype](temp / counts)
 
 def downsample_with_max_pooling(array, factor):
+  """
+  Downsample by picking the maximum value within a
+  cuboid specified by factor. That is, a reduction factor
+  of 2x2 works by summarizing many 2x2 cuboids. If factor's 
+  length is smaller than array.shape, the remaining factors will
+  be filled with 1.
+  """
   factor = validate_factor(array, factor)
   if np.all(np.array(factor, int) == 1):
       return array
@@ -124,6 +135,16 @@ def downsample_with_max_pooling(array, factor):
   return output
 
 def downsample_segmentation(data, factor):
+  """
+  Downsample by picking the most frequent value within a
+  2x2 square for each 2D image within a 3D stack if factor
+  is specified such that a power of two downsampling is possible.
+
+  Otherwise, downsample by striding.
+
+  If factor has fewer parameters than data.shape, the remainder
+  are assumed to be 1.
+  """
   if len(factor) == 4:
     assert factor[3] == 1 
     factor = factor[:3]
@@ -224,7 +245,11 @@ def downgrade_type(arr):
   return arr
 
 def downsample_with_striding(array, factor): 
-    """Downsample x by factor using striding.
+    """
+    Downsample x by factor using striding.
+
+    If factor has fewer parameters than data.shape, the remainder
+    are assumed to be 1.
 
     @return: The downsampled array, of the same type as x.
     """

--- a/python/test/downsample_test.py
+++ b/python/test/downsample_test.py
@@ -33,6 +33,33 @@ image3x3x3 = np.array([
   ],
 ])
 
+image4x4x4 = np.array([ 
+  [ #z 0    1    2   3 
+    [ [1], [1], [1], [1] ], # y=0
+    [ [1], [1], [1], [1] ], # y=1      # x=0
+    [ [1], [1], [1], [1] ], # y=2
+    [ [1], [1], [1], [1] ], # y=3
+  ], 
+  [
+    [ [2], [2], [2], [2] ], # y=0
+    [ [2], [2], [2], [2] ], # y=1      # x=1
+    [ [2], [2], [2], [2] ], # y=2
+    [ [2], [2], [2], [2] ], # y=3
+  ], 
+  [
+    [ [3], [3], [3], [3] ], # y=0
+    [ [3], [3], [3], [3] ], # y=1      # x=2
+    [ [3], [3], [3], [3] ], # y=2
+    [ [3], [3], [3], [3] ], # y=3
+  ],
+  [
+    [ [4], [4], [4], [4] ], # y=0
+    [ [4], [4], [4], [4] ], # y=1      # x=3
+    [ [4], [4], [4], [4] ], # y=2
+    [ [4], [4], [4], [4] ], # y=3
+  ], 
+])
+
 def test_even_odd():
   evenimg = downsample.odd_to_even(image2x2x2)
   assert np.array_equal(evenimg, image2x2x2)
@@ -189,4 +216,92 @@ def test_downsample_segmentation_4x_x():
   result = downsamplefn(result, (1,2,2))
   assert result.shape == (1024, 16, 128, 1)
 
+def test_downsample_max_pooling():
+  for dtype in (np.int8, np.float32):
+    cases = [
+      np.array([ [ -1, 0 ], [ 0, 0 ] ], dtype=dtype), 
+      np.array([ [ 0, 0 ], [ 0, 0 ] ], dtype=dtype), 
+      np.array([ [ 0, 1 ], [ 0, 0 ] ], dtype=dtype),
+      np.array([ [ 0, 1 ], [ 1, 0 ] ], dtype=dtype),
+      np.array([ [ 0, 1 ], [ 0, 2 ] ], dtype=dtype)
+    ]
+
+    for i in xrange(len(cases)):
+      case = cases[i]
+      result = downsample.downsample_with_max_pooling(case, (1, 1))
+      assert np.all(result == cases[i])
+
+    answers = [ 0, 0, 1, 1, 2 ]
+
+    for i in xrange(len(cases)):
+      case = cases[i]
+      result = downsample.downsample_with_max_pooling(case, (2, 2))
+      assert result == answers[i]
+
+
+    cast = lambda arr: np.array(arr, dtype=dtype) 
+
+    answers = map(cast, [  
+      [[ 0, 0 ]],
+      [[ 0, 0 ]],
+      [[ 0, 1 ]],
+      [[ 1, 1 ]],
+      [[ 0, 2 ]],
+    ])
+
+    for i in xrange(len(cases)):
+      case = cases[i]
+      result = downsample.downsample_with_max_pooling(case, (2, 1))
+      assert np.all(result == answers[i])
+
+    answers = map(cast, [  
+      [[ 0 ], [ 0 ]],
+      [[ 0 ], [ 0 ]],
+      [[ 1 ], [ 0 ]],
+      [[ 1 ], [ 1 ]],
+      [[ 1 ], [ 2 ]],
+    ])
+
+    for i in xrange(len(cases)):
+      case = cases[i]
+      result = downsample.downsample_with_max_pooling(case, (1, 2))
+      assert np.all(result == answers[i])
+
+  result = downsample.downsample_with_max_pooling(image4x4x4, (2, 2, 2))
+  answer = cast([
+    [
+      [ [2], [2] ], # y=0    # x = 0
+      [ [2], [2] ]  # y=1
+    ],
+    [
+      [ [4], [4] ], # y = 0     # x = 1
+      [ [4], [4] ]  # y = 1
+    ]
+  ])
+
+  assert np.all(result == answer)
+
+  result = downsample.downsample_with_max_pooling(image4x4x4, (2, 2, 1))
+  answer = cast([
+    [
+      [ [2], [2], [2], [2] ], # y=0    # x = 0
+      [ [2], [2], [2], [2] ]  # y=1
+    ],
+    [
+      [ [4], [4], [4], [4] ], # y = 0     # x = 1
+      [ [4], [4], [4], [4] ]  # y = 1
+    ]
+  ])
+
+  assert np.all(result == answer)
+
+  result = downsample.downsample_with_max_pooling(image4x4x4, (4, 2, 1))
+  answer = cast([
+    [
+      [ [4], [4], [4], [4] ], # y = 0     # x = 1
+      [ [4], [4], [4], [4] ]  # y = 1
+    ]
+  ])
+
+  assert np.all(result == answer)
 


### PR DESCRIPTION
For layer types where the voxel value is a scalar activations (e.g. errors),
max pooling probably makes more sense.

Related to #88