### PR TITLE
using graph servers full UInt64 vertex labels as mesh id

### DIFF
--- a/python/ext/third_party/yacn/chunked_regiongraph/ChunkedGraphs.jl
+++ b/python/ext/third_party/yacn/chunked_regiongraph/ChunkedGraphs.jl
@@ -1,6 +1,6 @@
 module ChunkedGraphs
 
-export update!, ChunkedGraph, add_atomic_edge!, add_atomic_vertex!, delete_atomic_edge!, leaves, bfs
+export update!, ChunkedGraph, add_atomic_edge!, add_atomic_vertex!, delete_atomic_edge!, get_vertex, leaves, bfs
 
 import DataStructures
 using Save
@@ -91,7 +91,7 @@ function get_chunk(g::ChunkedGraph, id::ChunkID)
 	return g.graphs[id]
 end
 
-function get_atomic_vertex(g::ChunkedGraph, label)
+function get_vertex(g::ChunkedGraph, label)
 	return g.vertices[label]
 end
 
@@ -194,7 +194,7 @@ function update!(c::Chunk)
 		end
 
 		for e in c.deleted_edges
-			u,v=lcG(map(x->get_atomic_vertex(c.chunked_graph,x),e)...)
+			u,v=lcG(map(x->get_vertex(c.chunked_graph,x),e)...)
 			@assert u.G == c
 			@assert v.G == c
 			MultiGraphs.delete_edge!(c.graph,u,v,e)
@@ -203,7 +203,7 @@ function update!(c::Chunk)
 		end
 
 		for e in c.added_edges
-			u,v=lcG(map(x->get_atomic_vertex(c.chunked_graph,x),e)...)
+			u,v=lcG(map(x->get_vertex(c.chunked_graph,x),e)...)
 			@assert u.G == c
 			@assert v.G == c
 			MultiGraphs.add_edge!(c.graph,u,v,e)
@@ -220,7 +220,9 @@ function update!(c::Chunk)
 
 			cc = MultiGraphs.connected_components(c.graph, dirty_vertices)
 			for component in cc
-				v=Vertex(unique_label(c.id), nothing, c.parent,component)
+				l=unique_label(c.id)
+				v=Vertex(l, nothing, c.parent,component)
+				c.chunked_graph.vertices[l]=v
 				for child in component
 					child.parent=v
 				end

--- a/python/ext/third_party/yacn/chunked_regiongraph/constants.jl
+++ b/python/ext/third_party/yacn/chunked_regiongraph/constants.jl
@@ -1,4 +1,4 @@
-const Int=Int32
+#const Int=Int32
 
 const bx = 2
 const by = 2

--- a/python/ext/third_party/yacn/chunked_regiongraph/prep.jl
+++ b/python/ext/third_party/yacn/chunked_regiongraph/prep.jl
@@ -1,4 +1,5 @@
 push!(LOAD_PATH, dirname(@__FILE__))
+include("../pre/Save.jl")
 include("tasks.jl")
 
 @pyimport neuroglancer.simple_task_queue.task_queue as task_queue

--- a/src/neuroglancer/object_graph_service.ts
+++ b/src/neuroglancer/object_graph_service.ts
@@ -20,10 +20,10 @@ export function getConnectedSegments (segment: Uint64) : Promise<Uint64[]> {
 	let promise = sendHttpRequest(openHttpRequest(`${GRAPH_BASE_URL}/1.0/node/${segment}`), 'arraybuffer');
     return promise.then(response => {
         let uint32 = new Uint32Array(response);
-        let final : Uint64[] = new Array(uint32.length);
+        let final : Uint64[] = new Array(uint32.length/2);
 
-        for (let i = 0; i < uint32.length; i++) {
-        	final[i] = new Uint64(uint32[i]);
+        for (let i = 0; i < uint32.length/2; i++) {
+        	final[i] = new Uint64(uint32[2*i], uint32[2*i+1]);
         }
 
         return final;


### PR DESCRIPTION
The agglomerated segment ids the graph server generates are now transferred to Neuroglancer as UInt64. That should avoid duplicate labels until we have datasets with more than 32 bit "real" supervoxels.

Also a function has been added to retrieve the next level child segments for a given label.