### PR TITLE
feat(scripts): created scripts directory and populated it

### DIFF
--- a/python/neuroglancer/pipeline/scripts/compute_bounds.py
+++ b/python/neuroglancer/pipeline/scripts/compute_bounds.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+"""
+This script can be used to determine the actual bounding box
+of a given layer. When a layer is first generated, it can
+come from any pipeline. e.g. ChunkFlow.jl or another custom
+method. These other methods are often agnostic to configuring
+neuroglancer info files correctly, which is critical to viewing
+the generated layer in neuroglancer and for processing them with
+the pipeline. This script can be run to find the right parameters
+for the info file.
+
+Example Command:
+
+  python compute_bounds.py gs://neuroglancer/DATASET/LAYER/
+
+Example Output to stdout:
+
+  bounds=Bbox([10,10,10], [138,138,138]) (size: [128,128,128]); chunk_size=[64,64,64]
+  
+"""
+
+import sys
+import os
+
+from tqdm import tqdm
+
+from neuroglancer.lib import Bbox, max2
+from neuroglancer.pipeline import Storage
+from neuroglancer.pipeline.volumes import CloudVolume
+
+layer_path = sys.argv[1]
+
+cv = CloudVolume(layer_path)
+
+print cv.key
+
+bboxes = []
+
+with Storage(layer_path) as stor:
+  for filename in tqdm(stor.list_files(prefix=cv.key), desc="Computing Bounds"):
+    bboxes.append( Bbox.from_filename(filename) )
+
+bounds = Bbox.expand(*bboxes)
+chunk_size = reduce(max2, map(lambda bbox: bbox.size3(), bboxes))
+print('bounds={} (size: {}); chunk_size={}'.format(bounds, bounds.size3(), chunk_size))
+
+
+
+
+
+
+

--- a/python/neuroglancer/pipeline/scripts/generate_manifests.py
+++ b/python/neuroglancer/pipeline/scripts/generate_manifests.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+"""
+This script is an alternative to deploying a cloud task.
+The first step is to download the mesh files:
+
+gsutil ls gs://neuroglancer/DATASET/LAYER/mesh/ > DATASET.txt
+
+Then you run this script:
+
+python generate_manifests.py DATASET
+
+You can probably do this faster in the cloud, but if you 
+want to keep things simple, you can process Pinky40_v11 
+in a few hrs or s1_v0.1 in an hour when they are meshed
+at a near isotropic mip level.
+"""
+
+from tqdm import tqdm
+import os
+import re
+import json
+from collections import defaultdict
+from neuroglancer.pipeline import Storage
+import sys
+
+lsfilename = '{}.txt'.format(sys.argv[1])
+
+with open(lsfilename) as f:
+  files = f.readlines()
+
+layer_path = os.path.dirname(files[0])
+files = [ os.path.basename(fname)[:-1] for fname in files ]
+
+segids = defaultdict(list)
+
+for fname in files:
+  segid, = re.match('(\d+):', fname).groups()
+  segid = int(segid)
+  segids[segid].append(fname)
+
+print(layer_path)
+with Storage(layer_path) as stor:
+  for segid, frags in tqdm(segids.items()):
+    stor.put_file(
+      file_path='{}:0'.format(segid),
+      content=json.dumps({ "fragments": frags }),
+      content_type='application/json',
+    )
+
+
+
+  

--- a/python/neuroglancer/pipeline/scripts/ngmesh2obj.py
+++ b/python/neuroglancer/pipeline/scripts/ngmesh2obj.py
@@ -1,0 +1,117 @@
+#!/use/bin/python
+
+"""
+This script can be used to generate standard obj files
+from precomputed neuroglancer meshes. This can be useful
+to e.g. provide meshes to 3D graphics artists.
+
+Mesh Format Documentation:
+https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#mesh-representation-of-segmented-object-surfaces
+
+The code is heavily based on the work done by Ricardo Kirkner. 
+
+Example Command:
+    python ngmesh2obj.py SEGID1 SEGID2 SEGID3 
+
+Example Output:
+    obj files for SEGID1 in ./SEGID1/
+    obj files for SEGID2 in ./SEGID2/
+    obj files for SEGID3 in ./SEGID3/
+"""
+
+from cStringIO import StringIO
+import gzip
+import json
+import os
+import struct 
+import sys
+
+from neuroglancer.lib import mkdir
+from neuroglancer.pipeline import CloudVolume, Storage
+
+def download_fragments(cloudpath, mesh_id):
+  vol = CloudVolume(cloudpath)
+  mesh_dir = vol.info['mesh']
+
+  download_path = os.path.join(mesh_dir, mesh_id + ':0')
+
+  with Storage(cloudpath) as stor:
+    fragments = json.loads(stor.get_file(download_path))['fragments']
+    paths = [ os.path.join(mesh_dir, fragment) for fragment in fragments ]
+    frag_datas = stor.get_files(paths)  
+  return frag_datas
+
+def decode_downloaded_data(frag_datas):
+  data = {}
+  for result in frag_datas:
+    data[result['filename']] = decode_mesh_buffer(result['content'])
+  return data
+
+def decode_mesh_buffer(fragment):
+  """
+  Mesh array format is: 
+  [ 
+      uint32:number of verticies, 
+      3 uint32s per vertex point (x,y,z), 
+      3 float32s per normal vector <x,y,z> 
+  ] 
+  """
+  num_vertices = struct.unpack("=I", fragment[0:4])[0]
+  vertex_data = fragment[4:4+(num_vertices*3)*4]
+  face_data = fragment[4+(num_vertices*3)*4:]
+  vertices = []
+
+  while vertex_data:
+    x = struct.unpack("=f", vertex_data[0:4])[0]
+    y = struct.unpack("=f", vertex_data[4:8])[0]
+    z = struct.unpack("=f", vertex_data[8:12])[0]
+    vertices.append((x,y,z))
+    vertex_data = vertex_data[12:]
+
+  faces = []
+  while face_data:
+    p = struct.unpack("=I", face_data[0:4])[0]
+    faces.append(p)
+    face_data = face_data[4:]
+
+  return {
+    'num_vertices': num_vertices, 
+    'vertices': vertices, 
+    'faces': faces
+  }
+
+def mesh_to_obj(fragment):
+  objdata = []
+  
+  for vertex in fragment['vertices']:
+    objdata.append('v %s %s %s' % (vertex[0], vertex[1], vertex[2]))
+  
+  faces = fragment['faces']
+  for i in xrange(0, len(faces), 3):
+    objdata.append('f %s %s %s' % (faces[i]+1, faces[i+1]+1, faces[i+2]+1))
+  
+  return objdata
+
+def save_mesh(mesh_id, meshdata):
+  mkdir(mesh_id)
+  for name, fragment in meshdata.items():
+    mesh_data = mesh_to_obj(fragment)
+    name = os.path.basename(name)
+    with open('./{}/{}.obj'.format(mesh_id, name), 'wb') as f:
+  f.write('\n'.join(mesh_data))
+
+if __name__ == '__main__':
+  prog, cloudpath = sys.argv[:2]
+  mesh_ids = sys.argv[2:]
+
+  for mesh_id in mesh_ids:
+    print "downloading " + mesh_id + '...'
+    meshdata = download_fragments(cloudpath, mesh_id)
+    print "decoding..."
+    meshdata = decode_downloaded_data(meshdata)
+    print "saving to obj..."
+    save_mesh(mesh_id, meshdata)
+    print "done."
+  
+
+

--- a/python/neuroglancer/pipeline/scripts/remap2npy.py
+++ b/python/neuroglancer/pipeline/scripts/remap2npy.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+"""
+This script is used to convert hdf5 segmentation remap files
+to npy format. Ran Lu's and Nick Turner's MST to remap converter 
+generates hdf5s using Julia. The format of these remap files is 
+simple. It's an array where the index of the array is the key
+and the value is the remap value. If the remap array is [5,2,39],
+this means remap segment ID 1 to 5, 2 to 2, and 3 to 39.
+
+This script reformats this array to be zero indexed to suit python
+and converts the array to npy format which will be used by the 
+WatershedRemapTask in the pipeline.
+
+Example Command Sequence:
+  gsutil cp path/to/remap.h5 .
+  python remap2npy.py remap.h5 # outputs remap.npy
+  gsutil cp -Z remap.npy gs://neuroglancer/DATASET/LAYER/
+"""
+
+import sys
+
+import h5py
+import numpy as np
+
+if len(sys.argv) == 1:
+  print "You must specify a remap .h5 file."
+  sys.exit()
+
+in_file = sys.argv[1]
+out_file = in_file.replace('.h5', '')
+
+with h5py.File(in_file,'r') as f:
+  arr = f['main'][:]
+
+print arr.shape, arr.dtype
+
+# These remap files are often created by julia or
+# matlab which assume 1-indexing. Add a new index
+# at 0 to realign with python's 0-indexing. 
+arr = np.concatenate( (np.array([0]), arr) )
+arr = arr.astype(np.uint32)
+
+np.save(out_file, arr)
+
+
+
+

--- a/python/neuroglancer/pipeline/scripts/super_downsample.py
+++ b/python/neuroglancer/pipeline/scripts/super_downsample.py
@@ -1,5 +1,20 @@
 #!/usr/bin/python
 
+"""
+WARNING: This script is defunct and broken, but could be revived
+if the need arose, though makes more sense to just run
+DownsampleTasks.
+
+This script will download an entire layer at a given resolution,
+execute downsampling, and upload the results. It generally creates
+multiple mip levels from a given layer. Because it downloads everything,
+the dataset has to be rather small for it to fit on a single machine.
+
+Example Command:
+  python super_downsample.py --image --dataset s1_v0 --mip 4  
+
+"""
+
 from __future__ import print_function
 
 import argparse


### PR DESCRIPTION
compute_bounds.py: given a layer, compute the bbox and chunk size so we can set info accurately
generate_manifests.py: generate manifests for a newly meshed object. Can also be done with tasks.
ngmesh2obj.py: convert a neuroglancer mesh into .obj representation. useful for sharing outside the lab.
remap2npy.py: convert an .h5 segmentation remap into a numpy representation used by the pipeline
super_downsample.py: for small volumes, you can superdownsample using this script, but it is generally supersceded by tasks.

Added documentation to scripts