### PR TITLE
fix(Storage): list_files consistent across services + flat option

### DIFF
--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -189,6 +189,18 @@ class Storage(ThreadedQueue):
         flat means only generate one level of a directory,
         while non-flat means generate all file paths with that 
         prefix.
+
+        Here's how flat=True handles different senarios:
+            1. partial directory name prefix = 'bigarr'
+                - lists the '' directory and filters on key 'bigarr'
+            2. full directory name prefix = 'bigarray'
+                - Same as (1), but using key 'bigarray'
+            3. full directory name + "/" prefix = 'bigarray/'
+                - Lists the 'bigarray' directory
+            4. partial file name prefix = 'bigarray/chunk_'
+                - Lists the 'bigarray/' directory and filters on 'chunk_'
+        
+        Return: generated sequence of file paths relative to layer_path
         """
 
         for f in self._interface.list_files(prefix, flat):

--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -182,8 +182,16 @@ class Storage(ThreadedQueue):
         with gzip.GzipFile(mode='rb', fileobj=stringio) as gfile:
             return gfile.read()
 
-    def list_files(self, prefix=""):
-        for f in self._interface.list_files(prefix):
+    def list_files(self, prefix="", flat=False):
+        """
+        List the files in the layer with the given prefix. 
+
+        flat means only generate one level of a directory,
+        while non-flat means generate all file paths with that 
+        prefix.
+        """
+
+        for f in self._interface.list_files(prefix, flat):
             yield f
 
 class FileInterface(object):
@@ -191,7 +199,6 @@ class FileInterface(object):
 
     def __init__(self, path):
         self._path = path
-
 
     def get_path_to_file(self, file_path):
         
@@ -225,15 +232,37 @@ class FileInterface(object):
         if os.path.exists(path):
             os.remove(path)
 
-    def list_files(self, prefix):
+    def list_files(self, prefix, flat):
+        """
+        List the files in the layer with the given prefix. 
+
+        flat means only generate one level of a directory,
+        while non-flat means generate all file paths with that 
+        prefix.
+        """
+
         layer_path = self.get_path_to_file("")        
-        path = os.path.join(layer_path, prefix)
-        path += "*"
+        path = os.path.join(layer_path, prefix) + '*'
+
         filenames = []
-        for file_path in glob(path):
-            if not os.path.isfile(file_path):
-                continue
-            filenames.append(os.path.basename(file_path))
+        remove = layer_path + '/'
+
+        if flat:
+            for file_path in glob(path):
+                if not os.path.isfile(file_path):
+                    continue
+                filename = file_path.replace(remove, '')
+                filenames.append(filename)
+        else:
+            subdir = os.path.join(layer_path, os.path.dirname(prefix))
+            for root, dirs, files in os.walk(subdir):
+                files = [ os.path.join(root, f) for f in files ]
+                files = [ f.replace(remove, '') for f in files ]
+                files = [ f for f in files if f[:len(prefix)] == prefix ]
+                
+                for filename in files:
+                    filenames.append(filename)
+            
         return _radix_sort(filenames).__iter__()
 
 class GoogleCloudStorageInterface(object):
@@ -277,15 +306,21 @@ class GoogleCloudStorageInterface(object):
         except google.cloud.exceptions.NotFound:
             pass
 
-    def list_files(self, prefix):
+    def list_files(self, prefix, flat=False):
         """
-        if there is no trailing slice we are looking for files with that prefix
+        List the files in the layer with the given prefix. 
+
+        flat means only generate one level of a directory,
+        while non-flat means generate all file paths with that 
+        prefix.
         """
         layer_path = self.get_path_to_file("")        
         path = os.path.join(layer_path, prefix)
         for blob in self._bucket.list_blobs(prefix=path):
-            filename =  os.path.basename(prefix) + blob.name[len(path):]
-            if '/' not in filename:
+            filename = blob.name.replace(layer_path + '/', '')
+            if not flat and filename[-1] != '/':
+                yield filename
+            elif flat and '/' not in blob.name.replace(path, ''):
                 yield filename
 
 class S3Interface(object):
@@ -336,16 +371,22 @@ class S3Interface(object):
         k.key = self.get_path_to_file(file_path)
         self._bucket.delete_key(k)
 
-    def list_files(self, prefix):
+    def list_files(self, prefix, flat=False):
         """
-        if there is no trailing slice we are looking for files with that prefix
+        List the files in the layer with the given prefix. 
+
+        flat means only generate one level of a directory,
+        while non-flat means generate all file paths with that 
+        prefix.
         """
-        from tqdm import tqdm
+
         layer_path = self.get_path_to_file("")        
         path = os.path.join(layer_path, prefix)
         for blob in self._bucket.list(prefix=path):
-            filename =  os.path.basename(prefix) + blob.name[len(path):]
-            if '/' not in filename:
+            filename = blob.name.replace(layer_path + '/', '')
+            if not flat and filename[-1] != '/':
+                yield filename
+            elif flat and '/' not in blob.name.replace(path, ''):
                 yield filename
 
 def _radix_sort(L, i=0):

--- a/python/neuroglancer/pipeline/task_creation.py
+++ b/python/neuroglancer/pipeline/task_creation.py
@@ -23,7 +23,7 @@ def create_ingest_task(storage, task_queue):
     """
     for filename in tqdm(storage.list_files(prefix='build/')):
         t = IngestTask(
-            chunk_path=storage.get_path_to_file('build/'+filename),
+            chunk_path=storage.get_path_to_file(filename),
             chunk_encoding='npz',
             layer_path=storage.get_path_to_file(''))
         task_queue.insert(t)
@@ -51,7 +51,7 @@ def compute_bigarray_bounding_box(storage):
     abs_x_min = abs_y_min = abs_z_min = float('inf')
     abs_x_max = abs_y_max = abs_z_max = 0
     for filename in tqdm(storage.list_files(prefix='bigarray/')):
-        match = re.match(r'(\d+):(\d+)_(\d+):(\d+)_(\d+):(\d+)$', filename)
+        match = re.search(r'(\d+):(\d+)_(\d+):(\d+)_(\d+):(\d+)$', filename)
         (_, _, 
         x_min, x_max,
         y_min, y_max,
@@ -72,7 +72,7 @@ def compute_build_bounding_box(storage):
     abs_x_max = abs_y_max = abs_z_max = 0
     chunk_sizes = set()
     for filename in tqdm(storage.list_files(prefix='build/')):
-        match = re.match(r'^(\d+)-(\d+)_(\d+)-(\d+)_(\d+)-(\d+)$', filename)
+        match = re.search(r'(\d+)-(\d+)_(\d+)-(\d+)_(\d+)-(\d+)$', filename)
         (x_min, x_max,
          y_min, y_max,
          z_min, z_max) = map(int, match.groups())
@@ -95,7 +95,7 @@ def compute_build_bounding_box(storage):
 
 def get_build_data_type_and_shape(storage):
     for filename in storage.list_files(prefix='build/'):
-        arr = chunks.decode_npz(storage.get_file('build/'+filename))
+        arr = chunks.decode_npz(storage.get_file(filename))
         return arr.dtype.name, arr.shape[3] #num_channels
 
 def create_info_file_from_build(storage, layer_type, resolution=[1,1,1], encoding='raw',

--- a/python/neuroglancer/pipeline/tasks.py
+++ b/python/neuroglancer/pipeline/tasks.py
@@ -320,7 +320,7 @@ class MeshManifestTask(RegisteredTask):
         Assumes that list files is most significant digix randix sorted
         """
         for filename in self._storage.list_files(prefix='mesh/{}'.format(self.prefix)):
-            match = re.match(r'(\d+):(\d+):(.*)$',filename)
+            match = re.search(r'(\d+):(\d+):(.*)$',filename)
             if not match: # a manifest file will not match
                 continue
             _id, lod, chunk_position = match.groups()

--- a/python/test/test_storage.py
+++ b/python/test/test_storage.py
@@ -86,25 +86,34 @@ def test_compression():
     shutil.rmtree("/tmp/removeme/compression")
 
 def test_list():  
-    urls = ["file:///tmp/removeme/list",
-            "gs://neuroglancer/removeme/list",
-            "s3://neuroglancer/removeme/list"]
+    urls = [
+        "file:///tmp/removeme/list",
+        "gs://neuroglancer/removeme/list",
+        "s3://neuroglancer/removeme/list"
+    ]
 
     for url in urls:
         with Storage(url, n_threads=5) as s:
+            print 'testing service:', url
             content = 'some_string'
             s.put_file('info1', content, compress=False)
             s.put_file('info2', content, compress=False)
             s.put_file('build/info3', content, compress=False)
+            s.put_file('level1/level2/info4', content, compress=False)
             s.wait()
             time.sleep(1) # sometimes it takes a moment for google to update the list
-            assert set(s.list_files(prefix='')) == set(['info1','info2'])
+            assert set(s.list_files(prefix='')) == set(['build/info3','info1', 'info2', 'level1/level2/info4'])
+            assert set(s.list_files(prefix='', flat=True)) == set(['info1','info2'])
             assert set(s.list_files(prefix='inf')) == set(['info1','info2'])
             assert set(s.list_files(prefix='info1')) == set(['info1'])
-            assert set(s.list_files(prefix='build')) == set([])
-            assert set(s.list_files(prefix='build/')) == set(['info3'])
+            assert set(s.list_files(prefix='build')) == set(['build/info3'])
+            assert set(s.list_files(prefix='build', flat=True)) == set([])
+            assert set(s.list_files(prefix='build/')) == set(['build/info3'])
+            assert set(s.list_files(prefix='build/', flat=True)) == set(['build/info3'])
+            assert set(s.list_files(prefix='level1/')) == set(['level1/level2/info4'])
+            assert set(s.list_files(prefix='level1/', flat=True)) == set([])
             assert set(s.list_files(prefix='nofolder/')) == set([])
-            for file_path in ('info1', 'info2', 'build/info3'):
+            for file_path in ('info1', 'info2', 'build/info3', 'level1/level2/info4'):
                 s.delete_file(file_path)
     
     shutil.rmtree("/tmp/removeme/list")

--- a/python/test/test_storage.py
+++ b/python/test/test_storage.py
@@ -103,16 +103,25 @@ def test_list():
             s.wait()
             time.sleep(1) # sometimes it takes a moment for google to update the list
             assert set(s.list_files(prefix='')) == set(['build/info3','info1', 'info2', 'level1/level2/info4'])
-            assert set(s.list_files(prefix='', flat=True)) == set(['info1','info2'])
+            
             assert set(s.list_files(prefix='inf')) == set(['info1','info2'])
             assert set(s.list_files(prefix='info1')) == set(['info1'])
             assert set(s.list_files(prefix='build')) == set(['build/info3'])
-            assert set(s.list_files(prefix='build', flat=True)) == set([])
             assert set(s.list_files(prefix='build/')) == set(['build/info3'])
-            assert set(s.list_files(prefix='build/', flat=True)) == set(['build/info3'])
             assert set(s.list_files(prefix='level1/')) == set(['level1/level2/info4'])
-            assert set(s.list_files(prefix='level1/', flat=True)) == set([])
             assert set(s.list_files(prefix='nofolder/')) == set([])
+
+            # Tests (1)
+            assert set(s.list_files(prefix='', flat=True)) == set(['info1','info2'])
+            assert set(s.list_files(prefix='inf', flat=True)) == set(['info1','info2'])
+            # Tests (2)
+            assert set(s.list_files(prefix='build', flat=True)) == set([])
+            # Tests (3)
+            assert set(s.list_files(prefix='level1/', flat=True)) == set([])
+            assert set(s.list_files(prefix='build/', flat=True)) == set(['build/info3'])
+            # Tests (4)
+            assert set(s.list_files(prefix='build/inf', flat=True)) == set(['build/info3'])
+
             for file_path in ('info1', 'info2', 'build/info3', 'level1/level2/info4'):
                 s.delete_file(file_path)
     

--- a/python/test/test_tasks.py
+++ b/python/test/test_tasks.py
@@ -71,7 +71,7 @@ def test_mesh():
              lod=0, simplification=5, segments=[])
     t.execute()
     assert storage.get_file('mesh/1:0:0-64_0-64_0-64') is not None 
-    assert list(storage.list_files('mesh/')) == ['1:0:0-64_0-64_0-64']
+    assert list(storage.list_files(prefix='mesh/')) == ['mesh/1:0:0-64_0-64_0-64']
 
 def test_manifest():
     
@@ -87,7 +87,6 @@ def test_manifest():
 
     def _delete_meshes():
         shutil.rmtree('/tmp/removeme/manifest', ignore_errors=True)
-
 
     _delete_meshes()
     _create_meshes()


### PR DESCRIPTION
List files now is consistent across filesystem, google storage, and
amazon s3. It now returns the relative path from the layer path
rather than trying to fake some kind of flat directory unsuccessfully.