### PR TITLE
fix(MeshTask): integer underflow causing large spikes in meshes

### DIFF
--- a/python/ext/third_party/mc/_mesher.pyx
+++ b/python/ext/third_party/mc/_mesher.pyx
@@ -12,7 +12,7 @@ from libcpp.string cimport string
 # c++ interface to cython
 cdef extern from "cMesher.h":
     cdef struct meshobj:
-        vector[unsigned int] points
+        vector[float] points
         vector[float] normals
         vector[unsigned int] faces
 

--- a/python/ext/third_party/mc/cMesher.h
+++ b/python/ext/third_party/mc/cMesher.h
@@ -12,7 +12,7 @@ Adapted to include passing of multidimensional arrays
 #include <zi/mesh/marching_cubes.hpp>
 
 struct meshobj {
-  std::vector<unsigned int> points;
+  std::vector<float> points;
   std::vector<float> normals;
   std::vector<unsigned int> faces;
 };


### PR DESCRIPTION
Ricardo Kirkner found that 'points', which should have been a float,
was instead an unsigned int. If the vertex position was ever negative,
which can happen near the edges of the volume, a large displacement would
appear.

This fix merely assigns the correct type to the python interface to the
c++ code.

Resolves #92