### PR TITLE
fix(mesher.so): compilation won't fail on gcc

### DIFF
--- a/python/ext/src/on_demand_object_mesh_generator.cc
+++ b/python/ext/src/on_demand_object_mesh_generator.cc
@@ -30,10 +30,15 @@
 #include <memory>
 
 // OS X doesn't have endian.h
-#if __has_include(<endian.h>)
-# include <endian.h>
+// To avoid problem with non-clang compilers not having this macro.
+#if defined(__has_include)
+# if __has_include(<endian.h>)
+#   include <endian.h>
+# else
+#   include "endian.h"
+# endif
 #else
-# include "endian.h"
+# include <endian.h>
 #endif
 
 namespace neuroglancer {


### PR DESCRIPTION
Previously compiling with clang was working, since it supports
the __has_include directive. Adding some logic to pick the
right endian.h file on gcc which doesn't support that directive.

https://clang.llvm.org/docs/LanguageExtensions.html#langext-has-include

Resolves #128