### PR TITLE
perf(Storage): gcloud content-encoding sent in 1 request instead of 2

### DIFF
--- a/python/neuroglancer/pipeline/storage.py
+++ b/python/neuroglancer/pipeline/storage.py
@@ -324,10 +324,9 @@ class GoogleCloudStorageInterface(object):
     def put_file(self, file_path, content, content_type, compress):
         key = self.get_path_to_file(file_path)
         blob = self._bucket.blob( key )
-        blob.upload_from_string(content, content_type)
         if compress:
             blob.content_encoding = "gzip"
-            blob.patch()
+        blob.upload_from_string(content, content_type)
 
     def get_file(self, file_path):
         key = self.get_path_to_file(file_path)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ Cython==0.25.2
 certifi==2016.9.26
 decorator==4.0.11
 google-api-python-client==1.6.2
-google-cloud==0.25
+google-cloud==0.26
 jsonschema==2.6.0
 networkx==1.11
 numpy==1.11.1


### PR DESCRIPTION
Reduces number of requests by 2x for uploading meshes and segmentation.