### PR TITLE
fix(ThreadedQueue): ensure processed matches task_done

### DIFF
--- a/python/neuroglancer/pipeline/threaded_queue.py
+++ b/python/neuroglancer/pipeline/threaded_queue.py
@@ -164,10 +164,9 @@ class ThreadedQueue(object):
     try:
       fn()
     finally:
-      self._queue.task_done()
-
       with self._processed_lock:
         self.processed += 1
+        self._queue.task_done()
 
   def wait(self):
     """


### PR DESCRIPTION
There's a bug where it's possible for the main thread to proceed after
queue.join() stops blocking butbefore self.processed is incremented,
resulting in a temporary discrepancy of 1. We invert the order of these
operations to ensure that join will not stop blocking until all tasks
are accounted for.