### PR TITLE
google-cloud 0.26 only works with google-cloud-storage version < 1.3.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,5 +21,6 @@ pytest==3.0.7
 tenacity==4.1.0
 google-api-python-client==1.6.2
 google-cloud==0.26
+google-cloud-storage=1.2.0
 jsonschema==2.6.0
 intern==0.9.4

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,6 +21,6 @@ pytest==3.0.7
 tenacity==4.1.0
 google-api-python-client==1.6.2
 google-cloud==0.26
-google-cloud-storage=1.2.0
+google-cloud-storage==1.2.0
 jsonschema==2.6.0
 intern==0.9.4


### PR DESCRIPTION
see this issue:
https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3736

if the version is not correct, will get error:
```
File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 502, in download_as_string
    self.download_to_file(string_buffer, client=client)
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 464, in download_to_file
    self._do_download(transport, file_obj, download_url, headers)
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/cloud/storage/blob.py", line 418, in _do_download
    download.consume(transport)
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/resumable_media/requests/download.py", line 96, in consume
    transport, method, url, **request_kwargs)
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/resumable_media/requests/_helpers.py", line 101, in http_request
    func, RequestsMixin._get_status_code, retry_strategy)
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google/resumable_media/_helpers.py", line 146, in wait_and_retry
    response = func()
  File "/Users/jpwu/libs/anaconda2/lib/python2.7/site-packages/google_auth_httplib2.py", line 198, in request
    uri, method, body=body, headers=request_headers, **kwargs)
TypeError: request() got an unexpected keyword argument 'data'
```
