### PR TITLE
fix(appengine/queue): lease api call waits for lease timer.

### DIFF
--- a/appengine/queue/taskqueue.py
+++ b/appengine/queue/taskqueue.py
@@ -226,8 +226,13 @@ class Task(object):
     def _set_retry_timer(self, lease_for):
         """
         Re insert in pq after certain time
+
+        It has to be a daemon so that the response is sent
+        without waiting for this to be finished
         """
-        Timer(lease_for, self.maybe_insert_into_pq, ()).start()
+        t = Timer(lease_for, self.maybe_insert_into_pq, ())
+        t.daemon = True
+        t.start()
  
     def lease(self, lease_for):
         """

--- a/appengine/queue/test.py
+++ b/appengine/queue/test.py
@@ -85,6 +85,25 @@ class TestHandlers(unittest.TestCase):
         self.assertEqual(response.status_int, 200)
         self.assertEqual(len(json.loads(response.body)), 1)
 
+    def test_lease_querystring(self):
+        request = webapp2.Request.blank('/myproject/taskqueue/myqueue/tasks')
+        request.method = 'POST'
+        body = {
+            "payloadBase64": 'somepayload',
+            "tag": 'task_a'
+        }
+        request.body = json.dumps(body)
+        response = request.get_response(taskqueue.app)
+
+        # Lease the only available task
+        request = webapp2.Request.blank(
+            '/myproject/taskqueue/myqueue/tasks/lease?tag=&leaseSecs=600&numTasks=1')
+        request.method = 'POST'
+        response = request.get_response(taskqueue.app)
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(len(json.loads(response.body)), 1)
+        self.assertEqual(len(taskqueue.queues['myqueue'].pq._pq), 0)
+
     def test_invalid_post(self):
         request = webapp2.Request.blank('/myproject/taskqueue/myqueue/tasks/oops')
         request.method = 'POST'


### PR DESCRIPTION
The timer thread was not started as a daemon, making a call
to lease with n seconds would take that same amount of time
to respond.