### PR TITLE
chore: upgrade to node 8.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 dist: trusty
 sudo: required
 node_js:
-- 7.3.0
+- 8.4.0
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
Looks like node 8 is a little more efficient (~7-10%) than node 6 (we're on node 7): 

https://hackernoon.com/upgrading-from-node-6-to-node-8-a-real-world-performance-comparison-3dfe1fbc92a3