### PR TITLE
fix: missing library and logic from for working with queues

### DIFF
--- a/python/neuroglancer/pipeline/task_queue.py
+++ b/python/neuroglancer/pipeline/task_queue.py
@@ -10,6 +10,7 @@ from functools import partial
 
 import googleapiclient.errors
 import googleapiclient.discovery
+import numpy as np
 
 from neuroglancer.pipeline.secrets import google_credentials, PROJECT_NAME, QUEUE_NAME
 from neuroglancer.pipeline.threaded_queue import ThreadedQueue
@@ -55,7 +56,13 @@ class RegisteredTask(object):
     def serialize(self):
         d = copy.deepcopy(self._args)
         d['class'] = self.__class__.__name__
-        return json.dumps(d)
+
+        def serializenumpy(obj):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            return obj
+
+        return json.dumps(d, default=serializenumpy)
 
     @property
     def payloadBase64(self):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,5 +15,6 @@ pytest==3.0.7
 python-jsonschema-objects==0.2.1
 requests==2.18.4
 sockjs-tornado==1.0.3
+tenacity==4.4.0
 tornado==4.4.2
 tqdm==4.7.6


### PR DESCRIPTION
Appearently we missed the np.ndarray serialization logic and
the tenacity requirement when merging the wms_bigbang.