### PR TITLE
feat(skeletons): precomputed support for skeletons

### DIFF
--- a/python/neuroglancer/skeleton.py
+++ b/python/neuroglancer/skeleton.py
@@ -27,14 +27,14 @@ class Skeleton(object):
         self.edges = np.array(edges, dtype='<u4')
         self.vertex_attributes = vertex_attributes
 
-    def encode(self, source):
+    def encode(self, source=None):
         result = io.BytesIO()
         edges = self.edges
         vertex_positions = self.vertex_positions
         vertex_attributes = self.vertex_attributes
         result.write(struct.pack('<II', vertex_positions.shape[0], edges.shape[0] // 2))
         result.write(vertex_positions.tobytes())
-        if len(source.vertex_attributes) > 0:
+        if source and len(source.vertex_attributes) > 0:
             for name, info in six.iteritems(source.vertex_attributes):
 
                 attribute = np.array(vertex_attributes[name],
@@ -71,3 +71,11 @@ class SkeletonSource(object):
         for k, v in six.iteritems(self.vertex_attributes):
             temp[k] = dict(dataType=np.dtype(v.data_type).name, numComponents=v.num_components)
         return temp
+
+if __name__ == '__main__':
+    # example on how to write an skeleton to disk
+    with open('/tmp/3','w') as f:
+        vertices = [[0.0,0.0,0.0],[1000.0, 0.0,0.0],[1000.0, 1000.0, 0.0],[0.0, 1000.0,0.0]]
+        edges = [0,1,1,2,2,3,3,0]
+        content = Skeleton(vertices, edges).encode()
+        f.write(content)

--- a/src/neuroglancer/datasource/brainmaps/frontend.ts
+++ b/src/neuroglancer/datasource/brainmaps/frontend.ts
@@ -21,7 +21,7 @@ import {BrainmapsInstance, INSTANCE_IDENTIFIERS, INSTANCE_NAMES, makeRequest, PR
 import {ChangeSpec, MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeSourceParameters} from 'neuroglancer/datasource/brainmaps/base';
 import {GetVolumeOptions, registerDataSourceFactory} from 'neuroglancer/datasource/factory';
 import {defineParameterizedMeshSource} from 'neuroglancer/mesh/frontend';
-import {parameterizedSkeletonSource} from 'neuroglancer/skeleton/frontend';
+import {defineParameterizedSkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {defineParameterizedVolumeChunkSource, MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
 import {StatusMessage} from 'neuroglancer/status';
@@ -31,7 +31,7 @@ import {parseArray, parseQueryStringParameters, parseXYZ, verifyEnumString, veri
 
 const VolumeChunkSource = defineParameterizedVolumeChunkSource(VolumeSourceParameters);
 const MeshSource = defineParameterizedMeshSource(MeshSourceParameters);
-const BaseSkeletonSource = parameterizedSkeletonSource(SkeletonSourceParameters);
+const BaseSkeletonSource = defineParameterizedSkeletonSource(SkeletonSourceParameters);
 
 const SERVER_DATA_TYPES = new Map<string, DataType>();
 SERVER_DATA_TYPES.set('UINT8', DataType.UINT8);
@@ -182,6 +182,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
       'meshName': validMesh.name,
       'changeSpec': this.changeSpec,
     });
+  }
+
+  getSkeletonSource(): null {
+    return null;
   }
 }
 

--- a/src/neuroglancer/datasource/dvid/frontend.ts
+++ b/src/neuroglancer/datasource/dvid/frontend.ts
@@ -458,6 +458,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   getMeshSource(): null {
     return null;
   }
+
+  getSkeletonSource(): null {
+    return null;
+  }
 }
 
 export function getShardedVolume(

--- a/src/neuroglancer/datasource/ndstore/frontend.ts
+++ b/src/neuroglancer/datasource/ndstore/frontend.ts
@@ -207,6 +207,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   getMeshSource(): null {
     return null;
   }
+
+  getSkeletonSource(): null {
+    return null;
+  }
 }
 
 const pathPattern = /^([^\/?]+)(?:\/([^\/?]+))?(?:\?(.*))?$/;

--- a/src/neuroglancer/datasource/nifti/frontend.ts
+++ b/src/neuroglancer/datasource/nifti/frontend.ts
@@ -58,6 +58,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   getMeshSource(): null {
     return null;
   }
+
+  getSkeletonSource(): null {
+    return null;
+  }
 }
 
 const VolumeChunkSource = defineParameterizedVolumeChunkSource(VolumeSourceParameters);

--- a/src/neuroglancer/datasource/precomputed/backend.ts
+++ b/src/neuroglancer/datasource/precomputed/backend.ts
@@ -15,7 +15,7 @@
  */
 
 import {registerChunkSource} from 'neuroglancer/chunk_manager/backend';
-import {MeshSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
+import {MeshSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters, SkeletonSourceParameters} from 'neuroglancer/datasource/precomputed/base';
 import {decodeJsonManifestChunk, decodeTriangleVertexPositionsAndIndices, FragmentChunk, ManifestChunk, ParameterizedMeshSource} from 'neuroglancer/mesh/backend';
 import {ChunkDecoder} from 'neuroglancer/sliceview/backend_chunk_decoders';
 import {decodeCompressedSegmentationChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/compressed_segmentation';
@@ -23,8 +23,11 @@ import {decodeJpegChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/jpe
 import {decodeRawChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/raw';
 import {ParameterizedVolumeChunkSource, VolumeChunk} from 'neuroglancer/sliceview/volume/backend';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
-import {Endianness} from 'neuroglancer/util/endian';
 import {openShardedHttpRequest, sendHttpRequest} from 'neuroglancer/util/http_request';
+import {decodeSkeletonVertexPositionsAndIndices, ParameterizedSkeletonSource, SkeletonChunk} from 'neuroglancer/skeleton/backend';
+import {VertexAttributeInfo} from 'neuroglancer/skeleton/base';
+import {convertEndian16, convertEndian32, Endianness} from 'neuroglancer/util/endian';
+import {DATA_TYPE_BYTES} from 'neuroglancer/util/data_type';
 
 const chunkDecoders = new Map<VolumeChunkEncoding, ChunkDecoder>();
 chunkDecoders.set(VolumeChunkEncoding.RAW, decodeRawChunk);
@@ -81,5 +84,52 @@ export class MeshSource extends ParameterizedMeshSource<MeshSourceParameters> {
                openShardedHttpRequest(parameters.baseUrls, requestPath), 'arraybuffer',
                cancellationToken)
         .then(response => decodeFragmentChunk(chunk, response));
+  }
+}
+
+
+
+function decodeSkeletonChunk(
+    chunk: SkeletonChunk, response: ArrayBuffer,
+    vertexAttributes: Map<string, VertexAttributeInfo>) {
+  let dv = new DataView(response);
+  let numVertices = dv.getUint32(0, true);
+  let numEdges = dv.getUint32(4, true);
+  const vertexPositionsStartOffset = 8;
+
+  let curOffset = 8 + numVertices * 4 * 3;
+  let attributes: Uint8Array[] = [];
+  for (let info of vertexAttributes.values()) {
+    const bytesPerVertex = DATA_TYPE_BYTES[info.dataType] * info.numComponents;
+    const totalBytes = bytesPerVertex * numVertices;
+    const attribute = new Uint8Array(response, curOffset, totalBytes);
+    switch (bytesPerVertex) {
+      case 2:
+        convertEndian16(attribute, Endianness.LITTLE);
+        break;
+      case 4:
+      case 8:
+        convertEndian32(attribute, Endianness.LITTLE);
+        break;
+    }
+    attributes.push(attribute);
+    curOffset += totalBytes;
+  }
+  chunk.vertexAttributes = attributes;
+  decodeSkeletonVertexPositionsAndIndices(
+      chunk, response, Endianness.LITTLE, /*vertexByteOffset=*/vertexPositionsStartOffset,
+      numVertices,
+      /*indexByteOffset=*/curOffset, /*numEdges=*/numEdges);
+}
+
+@registerChunkSource(SkeletonSourceParameters)
+export class SkeletonSource extends ParameterizedSkeletonSource<SkeletonSourceParameters> {
+  download(chunk: SkeletonChunk, cancellationToken: CancellationToken) {
+    const {parameters} = this;
+    let requestPath = `${parameters.key}/${chunk.objectId}`;
+    return sendHttpRequest(
+               openShardedHttpRequest(parameters.baseUrls, requestPath), 'arraybuffer',
+               cancellationToken)
+        .then(response => decodeSkeletonChunk(chunk, response, parameters.vertexAttributes));
   }
 }

--- a/src/neuroglancer/datasource/precomputed/base.ts
+++ b/src/neuroglancer/datasource/precomputed/base.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {VertexAttributeInfo} from 'neuroglancer/skeleton/base';
+
 export enum VolumeChunkEncoding {
   RAW,
   JPEG,
@@ -43,4 +45,17 @@ export class MeshSourceParameters {
   }
 
   static RPC_ID = 'precomputed/MeshSource';
+}
+
+
+export class SkeletonSourceParameters {
+  baseUrls: string[];
+  key: string;
+  vertexAttributes: Map<string, VertexAttributeInfo>;
+
+  static stringify(parameters: SkeletonSourceParameters) {
+    return `precomputed:skeleton:${parameters['baseUrls'][0]}/${parameters['key']}`;
+  }
+
+  static RPC_ID = 'precomputed/SkeletonSource';
 }

--- a/src/neuroglancer/datasource/python/frontend.ts
+++ b/src/neuroglancer/datasource/python/frontend.ts
@@ -24,7 +24,7 @@ import {registerDataSourceFactory} from 'neuroglancer/datasource/factory';
 import {MeshSourceParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/python/base';
 import {defineParameterizedMeshSource} from 'neuroglancer/mesh/frontend';
 import {VertexAttributeInfo} from 'neuroglancer/skeleton/base';
-import {parameterizedSkeletonSource} from 'neuroglancer/skeleton/frontend';
+import {defineParameterizedSkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType, DEFAULT_MAX_VOXELS_PER_CHUNK_LOG2, getNearIsotropicBlockSize, getTwoDimensionalBlockSize} from 'neuroglancer/sliceview/base';
 import {VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {defineParameterizedVolumeChunkSource, MultiscaleVolumeChunkSource as GenericMultiscaleVolumeChunkSource} from 'neuroglancer/sliceview/volume/frontend';
@@ -34,7 +34,7 @@ import {parseArray, parseFixedLengthArray, verify3dDimensions, verify3dScale, ve
 
 const VolumeChunkSource = defineParameterizedVolumeChunkSource(VolumeChunkSourceParameters);
 const MeshSource = defineParameterizedMeshSource(MeshSourceParameters);
-const BaseSkeletonSource = parameterizedSkeletonSource(SkeletonSourceParameters);
+const BaseSkeletonSource = defineParameterizedSkeletonSource(SkeletonSourceParameters);
 
 interface ScaleInfo {
   key: string;
@@ -164,6 +164,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
       baseUrls: this.baseUrls,
       key: this.key,
     });
+  }
+
+  getSkeletonSource(): null {
+    return null;
   }
 }
 

--- a/src/neuroglancer/datasource/render/frontend.ts
+++ b/src/neuroglancer/datasource/render/frontend.ts
@@ -291,6 +291,10 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
   getMeshSource(): null {
     return null;
   }
+
+  getSkeletonSource(): null {
+    return null;
+  }
 }
 
 export function computeStackHierarchy(stackInfo: StackInfo, tileSize: number) {

--- a/src/neuroglancer/skeleton/frontend.ts
+++ b/src/neuroglancer/skeleton/frontend.ts
@@ -237,11 +237,12 @@ export class SkeletonLayer extends RefCounted {
   draw(
       renderContext: SliceViewPanelRenderContext, layer: RenderLayer, renderHelper: RenderHelper,
       lineWidth?: number) {
+
     if (lineWidth === undefined) {
       lineWidth = renderContext.emitColor ? 1 : 5;
     }
     let {gl, source, displayState} = this;
-    let alpha = Math.min(1.0, displayState.objectAlpha.value);
+    let alpha = 1.0 //disable alpha Math.min(1.0, displayState.objectAlpha.value);
     if (alpha <= 0.0) {
       // Skip drawing.
       return;
@@ -413,7 +414,7 @@ export class ParameterizedSkeletonSource<Parameters> extends SkeletonSource {
 /**
  * Defines a SkeletonSource for which all state is encapsulated in an object of type Parameters.
  */
-export function parameterizedSkeletonSource<Parameters>(
+export function defineParameterizedSkeletonSource<Parameters>(
     parametersConstructor: ChunkSourceParametersConstructor<Parameters>) {
   const newConstructor =
       class SpecializedParameterizedSkeletonSource extends ParameterizedSkeletonSource<Parameters> {

--- a/src/neuroglancer/sliceview/volume/frontend.ts
+++ b/src/neuroglancer/sliceview/volume/frontend.ts
@@ -17,6 +17,7 @@
 import {ChunkSourceParametersConstructor} from 'neuroglancer/chunk_manager/base';
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
 import {MeshSource} from 'neuroglancer/mesh/frontend';
+import {SkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType} from 'neuroglancer/sliceview/base';
 import {MultiscaleSliceViewChunkSource, SliceViewChunk, SliceViewChunkSource} from 'neuroglancer/sliceview/frontend';
 import {VolumeChunkSource as VolumeChunkSourceInterface, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
@@ -224,4 +225,7 @@ export interface MultiscaleVolumeChunkSource extends MultiscaleSliceViewChunkSou
    * This only makes sense if volumeType === VolumeType.SEGMENTATION.
    */
   getMeshSource: () => MeshSource | null;
+
+  getSkeletonSource: () => SkeletonSource | null;
+
 }


### PR DESCRIPTION
Skeletons were supported by the python backend.
But not all the code necesary for doing so was available.

We were instead using the synapse layer to display skeletons
but the problem is that large skeletons were not able to be
displayed given the max lenght of an url.

Both solutions above required running a local server, the precomputed
datasource let us use s3 or gcs to serve large amounts of data directly,
but precomputed only supported images and meshes, it can now supporty
skeletons.

skeletons.py implements encoding for a very simple binary format for
skeletons, which is similar in nature to how meshes are saved.
We don't yet have any decoder implementation.

The neuroglancer frontend it's very flexible in how to display skeletons,
it allows you to store abitrary information for every vertex, and that
can be used to represent skeletons in complex ways.
The data is tranform into the visual represetantion by means of a
fragment shader that can be modify by ther users.
./src/neuroglancer/sliceview/image_layer_rendering.md

We currently only support specifying the vertex position and nothing else.
But this limitation can be easily lift. We would need to store metadata
about the vertex attributes in the info file. And we will do it if the
need for this arises. Our current strategy was to deployed what it's
currently required.

All we store in the info file now is the relative path to the folder
containing the skeletons, analogously as how we store meshes.
for example a new info file might look like:

{
	"num_channels": 1,
	"type": "segmentation",
	"data_type": "uint32",
	"skeletons": "skeletons",
	"mesh": "mesh_mip_3_err_40",
	"scales": [{
		"encoding": "raw",
		"chunk_sizes": [
			[64,...

information on how to write shaders can be found here:
./src/neuroglancer/sliceview/image_layer_rendering.md