### PR TITLE
Fix state server

### DIFF
--- a/src/neuroglancer/state_server.ts
+++ b/src/neuroglancer/state_server.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2017 Thomas Macrina
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Create an object to handle multiple state server attributes.
+ *
+ * We don't use this, right now. We use a single TrackableValue for only the 
+ * url of the state server. If we wanted to pass additional information, we
+ * could consider using an object structure like this.
+ */
+
+import {RefCounted} from 'neuroglancer/util/disposable';
+import {verifyObject, verifyObjectProperty} from 'neuroglancer/util/json';
+import {NullarySignal} from 'neuroglancer/util/signal';
+
+export class StateServer extends RefCounted {
+  changed = new NullarySignal();
+  constructor(public url = '') {
+    super();
+  }
+
+  reset() {
+    this.url = '';
+  }
+
+  restoreState(obj: any) {
+    try {
+      verifyObject(obj);
+      verifyObjectProperty(obj, 'url', x => {
+        if (x !== undefined) {
+          this.url = x;
+        }
+      });
+    } catch {
+      this.reset();
+    }
+    this.changed.dispatch();
+  }
+
+  toJSON() {
+    let empty = true;
+    let obj: any = {};
+    if (this.url !== '') {
+      empty = false
+      obj['url'] = this.url
+    }
+    if (empty) {
+      return undefined;
+    }
+    return obj;
+  }
+}

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -42,7 +42,6 @@ import {GL} from 'neuroglancer/webgl/context';
 import {RPC} from 'neuroglancer/worker_rpc';
 import {StatusMessage} from 'neuroglancer/status';
 
-
 require('./viewer.css');
 require('./help_button.css');
 require('neuroglancer/noselect.css');
@@ -58,6 +57,10 @@ export function getLayoutByName(obj: any) {
 export function validateLayoutName(obj: any) {
   let layout = getLayoutByName(obj);
   return layout[0];
+}
+
+export function validateStateServer(obj: any) {
+  return obj
 }
 
 export class DataManagementContext extends RefCounted {
@@ -123,6 +126,7 @@ export class Viewer extends RefCounted implements ViewerState {
   keyCommands = new Map<string, (this: Viewer) => void>();
   layerSpecification: LayerListSpecification;
   layoutName = new TrackableValue<string>(LAYOUTS[0][0], validateLayoutName);
+  stateServer = new TrackableValue<string>('', validateStateServer)
 
   state = new CompoundTrackable();
 
@@ -170,6 +174,7 @@ export class Viewer extends RefCounted implements ViewerState {
     state.add('perspectiveZoom', this.perspectiveNavigationState.zoomFactor);
     state.add('showSlices', this.showPerspectiveSliceViews);
     state.add('layout', this.layoutName);
+    state.add('stateServer', this.stateServer);
 
     this.registerDisposer(this.navigationState.changed.add(() => {
       this.handleNavigationStateChanged();
@@ -190,6 +195,7 @@ export class Viewer extends RefCounted implements ViewerState {
         this.navigationState.reset();
         this.perspectiveNavigationState.pose.orientation.reset();
         this.perspectiveNavigationState.zoomFactor.reset();
+        this.stateServer.reset();
         this.resetInitiated.dispatch();
         if (!overlaysOpen && this.options.showLayerDialog && this.visibility.visible) {
           new LayerDialog(this.layerSpecification);


### PR DESCRIPTION
Update neuroglancer frontend to handle a state server, with identical functionality as before `Upstream google` merge.

Append `stateServer` key to the neuroglancer URL's ending state JSON, and use the server URL as the  value.