### PR TITLE
Chunk based supervoxel loading from Chunked Graph

### DIFF
--- a/src/neuroglancer/chunk_manager/backend.ts
+++ b/src/neuroglancer/chunk_manager/backend.ts
@@ -231,7 +231,7 @@ export class ChunkSource extends ChunkSourceBase {
   }
 }
 
-function startChunkDownload(chunk: Chunk) {
+export function startChunkDownload(chunk: Chunk) {
   const downloadCancellationToken = chunk.downloadCancellationToken = new CancellationTokenSource();
   chunk.source!.download(chunk, downloadCancellationToken)
       .then(
@@ -250,7 +250,7 @@ function startChunkDownload(chunk: Chunk) {
           });
 }
 
-function cancelChunkDownload(chunk: Chunk) {
+export function cancelChunkDownload(chunk: Chunk) {
   const token = chunk.downloadCancellationToken!;
   chunk.downloadCancellationToken = undefined;
   token.cancel();

--- a/src/neuroglancer/chunked_graph/base.ts
+++ b/src/neuroglancer/chunked_graph/base.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2017 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SliceViewChunkSource, SliceViewChunkSpecification, SliceViewChunkSpecificationBaseOptions, SliceViewSourceOptions} from 'neuroglancer/sliceview/base';
+import {getCombinedTransform} from 'neuroglancer/sliceview/base';
+import {vec3} from 'neuroglancer/util/geom';
+
+export interface ChunkedGraphChunkSpecificationSourceOptions {
+  chunkedGraphSourceOptions: ChunkedGraphSourceOptions;
+}
+
+export interface ChunkedGraphSourceOptions extends SliceViewSourceOptions {
+}
+
+export interface ChunkedGraphSource extends SliceViewChunkSource {
+  spec: ChunkedGraphChunkSpecification;
+}
+
+export interface ChunkedGraphChunkSpecificationOptions extends
+    SliceViewChunkSpecificationBaseOptions {
+  chunkDataSize: vec3;
+}
+
+export interface ChunkedGraphChunkSpecificationDefaultChunkSizeOptions extends
+    SliceViewChunkSpecificationBaseOptions {
+  chunkDataSize?: vec3;
+}
+
+export interface ChunkedGraphChunkSpecificationGetDefaultsOptions extends
+    ChunkedGraphChunkSpecificationDefaultChunkSizeOptions,
+    ChunkedGraphChunkSpecificationSourceOptions {}
+
+/**
+ * Specifies a chunk layout and voxel size.
+ */
+export class ChunkedGraphChunkSpecification extends SliceViewChunkSpecification {
+  constructor(options: ChunkedGraphChunkSpecificationOptions) {
+    super(options);
+  }
+
+  static make(options: ChunkedGraphChunkSpecificationOptions&
+              {chunkedGraphSourceOptions: ChunkedGraphSourceOptions}) {
+    return new ChunkedGraphChunkSpecification(Object.assign(
+        {}, options,
+        {transform: getCombinedTransform(options.transform, options.chunkedGraphSourceOptions)}));
+  }
+
+  static fromObject(msg: any) {
+    return new ChunkedGraphChunkSpecification(msg);
+  }
+
+  static withDefaults(options: ChunkedGraphChunkSpecificationGetDefaultsOptions) {
+    let {transform, lowerVoxelBound, upperVoxelBound, chunkDataSize} = options;
+    transform = getCombinedTransform(transform, options.chunkedGraphSourceOptions);
+
+    if (chunkDataSize === undefined) {
+      chunkDataSize = vec3.clone(upperVoxelBound);
+      if (lowerVoxelBound !== undefined) {
+        for (let i = 0; i < 3; i++) {
+          chunkDataSize[i] += Math.abs(lowerVoxelBound[i]);
+        }
+      }
+    }
+
+    return new ChunkedGraphChunkSpecification(
+        Object.assign({}, options, {transform, chunkDataSize}));
+  }
+
+  toObject(): ChunkedGraphChunkSpecificationOptions {
+    return {
+      transform: this.chunkLayout.transform,
+      chunkDataSize: this.chunkDataSize,
+      voxelSize: this.voxelSize,
+      lowerVoxelBound: this.lowerVoxelBound,
+      upperVoxelBound: this.upperVoxelBound,
+      lowerClipBound: this.lowerClipBound,
+      upperClipBound: this.upperClipBound,
+      baseVoxelOffset: this.baseVoxelOffset,
+    };
+  }
+}
+
+export const CHUNKED_GRAPH_LAYER_RPC_ID = 'ChunkedGraphLayer';

--- a/src/neuroglancer/datasource/precomputed/base.ts
+++ b/src/neuroglancer/datasource/precomputed/base.ts
@@ -30,6 +30,13 @@ export class VolumeChunkSourceParameters {
   static RPC_ID = 'precomputed/VolumeChunkSource';
 }
 
+export class ChunkedGraphSourceParameters {
+  baseUrls: string[];
+  path: string;
+
+  static RPC_ID = 'precomputed/ChunkedGraphSource';
+}
+
 
 export class MeshSourceParameters {
   baseUrls: string[];

--- a/src/neuroglancer/gpu_hash/hash_table.ts
+++ b/src/neuroglancer/gpu_hash/hash_table.ts
@@ -19,7 +19,7 @@ import {Uint64} from 'neuroglancer/util/uint64';
 
 export const NUM_ALTERNATIVES = 3;
 
-const DEFAULT_LOAD_FACTOR = 0.9;
+const DEFAULT_LOAD_FACTOR = 0.8;
 
 const DEBUG = false;
 
@@ -139,17 +139,15 @@ export abstract class HashTableBase {
   /**
    * Iterates over the Uint64 keys contained in the hash set.
    *
-   * The same temp value will be modified and yielded at every iteration.
+   * Creates a new Uint64 object at every iteration (otherwise spread and Array.from() fail)
    */
-  * keys(temp = new Uint64()) {
+  * keys() {
     let {emptyLow, emptyHigh, entryStride} = this;
     let {table} = this;
     for (let i = 0, length = table.length; i < length; i += entryStride) {
       let low = table[i], high = table[i + 1];
       if (low !== emptyLow || high !== emptyHigh) {
-        temp.low = low;
-        temp.high = high;
-        yield temp;
+        yield new Uint64(low, high);
       }
     }
   }
@@ -254,6 +252,16 @@ export abstract class HashTableBase {
     ++this.generation;
     this.clearTable();
     return true;
+  }
+
+  reserve(x: number) {
+    if (x > this.capacity) {
+      this.backupPending();
+      this.grow(x);
+      this.restorePending();
+      return true;
+    }
+    return false;
   }
 
   protected swapPending(table: Uint32Array, offset: number) {
@@ -404,8 +412,8 @@ export class HashSetUint64 extends HashTableBase {
   }
 
   /**
-   * Iterates over the keys.  The same temporary value will be modified and yielded at every
-   * iteration.
+   * Iterates over the keys.
+   * Creates a new Uint64 object at every iteration (otherwise spread and Array.from() fail)
    */
   [Symbol.iterator]() {
     return this.keys();
@@ -472,29 +480,26 @@ export class HashMapUint64 extends HashTableBase {
   }
 
   /**
-   * Iterates over entries.  The same temporary value will be modified and yielded at every
-   * iteration.
+   * Iterates over entries.
+   * Creates new Uint64 objects at every iteration (otherwise spread and Array.from() fail)
    */
   [Symbol.iterator]() {
     return this.entries();
   }
 
   /**
-   * Iterates over entries.  The same temporary value will be modified and yielded at every
-   * iteration.
+   * Iterates over entries.
+   * Creates new Uint64 objects at every iteration (otherwise spread and Array.from() fail)
    */
-  * entries(temp: [Uint64, Uint64] = [new Uint64(), new Uint64()]) {
+  * entries() {
     let {emptyLow, emptyHigh, entryStride} = this;
     let {table} = this;
-    let [key, value] = temp;
     for (let i = 0, length = table.length; i < length; i += entryStride) {
       let low = table[i], high = table[i + 1];
       if (low !== emptyLow || high !== emptyHigh) {
-        key.low = low;
-        key.high = high;
-        value.low = table[i + 2];
-        value.high = table[i + 3];
-        yield temp;
+        let key = new Uint64(low, high);
+        let value = new Uint64(table[i + 2], table[i + 3]);
+        yield [key, value];
       }
     }
   }

--- a/src/neuroglancer/gpu_hash/hash_table.ts
+++ b/src/neuroglancer/gpu_hash/hash_table.ts
@@ -19,6 +19,8 @@ import {Uint64} from 'neuroglancer/util/uint64';
 
 export const NUM_ALTERNATIVES = 3;
 
+// For 3 hash functions, a DEFAULT_LOAD_FACTOR of 0.8 reliably avoids
+// expensive rehashing caused by unresolvable collisions.
 const DEFAULT_LOAD_FACTOR = 0.8;
 
 const DEBUG = false;

--- a/src/neuroglancer/mesh/frontend.ts
+++ b/src/neuroglancer/mesh/frontend.ts
@@ -16,7 +16,7 @@
 
 import {ChunkState} from 'neuroglancer/chunk_manager/base';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
-import {ChunkedGraph} from 'neuroglancer/chunked_graph/frontend';
+import {ChunkedGraphLayer} from 'neuroglancer/chunked_graph/frontend';
 import {FRAGMENT_SOURCE_RPC_ID, MESH_LAYER_RPC_ID} from 'neuroglancer/mesh/base';
 import {PerspectiveViewRenderContext, PerspectiveViewRenderLayer} from 'neuroglancer/perspective_view/render_layer';
 import {forEachSegment3DToDraw, getObjectColor, registerRedrawWhenSegmentationDisplayState3DChanged, SegmentationDisplayState3D, SegmentationLayerSharedObject} from 'neuroglancer/segmentation_display_state/frontend';
@@ -105,7 +105,7 @@ export class MeshLayer extends PerspectiveViewRenderLayer {
 
   constructor(
       public chunkManager: ChunkManager,
-      public chunkedGraph: ChunkedGraph,
+      public chunkedGraph: ChunkedGraphLayer|null,
       public source: MeshSource,
       public displayState: SegmentationDisplayState3D) {
     super();
@@ -117,7 +117,7 @@ export class MeshLayer extends PerspectiveViewRenderLayer {
     sharedObject.RPC_TYPE_ID = MESH_LAYER_RPC_ID;
     sharedObject.initializeCounterpartWithChunkManager({
       'source': source.addCounterpartRef(),
-      'chunkedGraph': chunkedGraph.addCounterpartRef(),
+      'chunkedGraph': chunkedGraph ? chunkedGraph.rpcId : null,
     });
     this.setReady(true);
     sharedObject.visibility.add(this.visibility);

--- a/src/neuroglancer/skeleton/backend.ts
+++ b/src/neuroglancer/skeleton/backend.ts
@@ -15,7 +15,7 @@
  */
 
 import {Chunk, ChunkSource} from 'neuroglancer/chunk_manager/backend';
-import {ChunkedGraph} from 'neuroglancer/chunked_graph/backend';
+import {ChunkedGraphLayer} from 'neuroglancer/chunked_graph/backend';
 import {decodeVertexPositionsAndIndices} from 'neuroglancer/mesh/backend';
 import {SegmentationLayerSharedObjectCounterpart} from 'neuroglancer/segmentation_display_state/backend';
 import {forEachRootSegment, getObjectKey} from 'neuroglancer/segmentation_display_state/base';
@@ -114,12 +114,12 @@ export class SkeletonSource extends ChunkSource {
 @registerSharedObject(SKELETON_LAYER_RPC_ID)
 export class SkeletonLayer extends SegmentationLayerSharedObjectCounterpart {
   source: SkeletonSource;
-  chunkedGraph: ChunkedGraph;
+  chunkedGraph: ChunkedGraphLayer | null;
 
   constructor(rpc: RPC, options: any) {
     super(rpc, options);
     this.source = this.registerDisposer(rpc.getRef<SkeletonSource>(options['source']));
-    this.chunkedGraph = this.registerDisposer(rpc.getRef<ChunkedGraph>(options['chunkedGraph']));
+    this.chunkedGraph = this.registerDisposer(rpc.get(options['chunkedGraph']));
     this.registerDisposer(this.chunkManager.recomputeChunkPriorities.add(() => {
       this.updateChunkPriorities();
     }));

--- a/src/neuroglancer/skeleton/frontend.ts
+++ b/src/neuroglancer/skeleton/frontend.ts
@@ -16,7 +16,7 @@
 
 import {ChunkState} from 'neuroglancer/chunk_manager/base';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
-import {ChunkedGraph} from 'neuroglancer/chunked_graph/frontend';
+import {ChunkedGraphLayer} from 'neuroglancer/chunked_graph/frontend';
 import {RenderLayer} from 'neuroglancer/layer';
 import {VoxelSize} from 'neuroglancer/navigation_state';
 import {PerspectiveViewRenderContext, PerspectiveViewRenderLayer} from 'neuroglancer/perspective_view/render_layer';
@@ -174,7 +174,7 @@ export class SkeletonLayer extends RefCounted {
 
   constructor(
       public chunkManager: ChunkManager,
-      public chunkedGraph: ChunkedGraph,
+      public chunkedGraph: ChunkedGraphLayer|null,
       public source: SkeletonSource,
       public voxelSizeObject: VoxelSize,
       public displayState: SkeletonLayerDisplayState) {
@@ -191,7 +191,7 @@ export class SkeletonLayer extends RefCounted {
     sharedObject.RPC_TYPE_ID = SKELETON_LAYER_RPC_ID;
     sharedObject.initializeCounterpartWithChunkManager({
       'source': source.addCounterpartRef(),
-      'chunkedGraph': chunkedGraph.addCounterpartRef(),
+      'chunkedGraph': chunkedGraph ? chunkedGraph.rpcId : null,
     });
 
     const vertexAttributes = this.vertexAttributes = [vertexPositionAttribute];

--- a/src/neuroglancer/sliceview/volume/frontend.ts
+++ b/src/neuroglancer/sliceview/volume/frontend.ts
@@ -15,11 +15,14 @@
  */
 
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
+import {ChunkedGraphSourceOptions} from 'neuroglancer/chunked_graph/base';
+import {ChunkedGraphChunkSource} from 'neuroglancer/chunked_graph/frontend';
 import {MeshSource} from 'neuroglancer/mesh/frontend';
 import {SkeletonSource} from 'neuroglancer/skeleton/frontend';
 import {DataType} from 'neuroglancer/sliceview/base';
 import {MultiscaleSliceViewChunkSource, SliceViewChunk, SliceViewChunkSource} from 'neuroglancer/sliceview/frontend';
 import {VolumeChunkSource as VolumeChunkSourceInterface, VolumeChunkSpecification, VolumeSourceOptions, VolumeType} from 'neuroglancer/sliceview/volume/base';
+import {Uint64Set} from 'neuroglancer/uint64_set';
 import {Disposable} from 'neuroglancer/util/disposable';
 import {vec3, vec3Key} from 'neuroglancer/util/geom';
 import {Uint64} from 'neuroglancer/util/uint64';
@@ -192,16 +195,17 @@ export interface MultiscaleVolumeChunkSource extends MultiscaleSliceViewChunkSou
   getMeshSource: () => MeshSource | null;
 
   /**
+   * Returns the associated chunked graph url, if there is one.
+   *
+   * This only makes sense if volumeType === VolumeType.SEGMENTATION.
+   */
+  getChunkedGraphUrl?: () => string | null;
+  getChunkedGraphSources?: (options: ChunkedGraphSourceOptions, rootSegments: Uint64Set) => ChunkedGraphChunkSource[][] | null;
+
+  /**
    * Returns the associated skeleton source, if there is one.
    *
    * This only makes sense if volumeType === VolumeType.SEGMENTATION.
    */
   getSkeletonSource?: () => SkeletonSource | null;
-
-  /**
-   * Returns the associated chunked graph server url, if there is one.
-   *
-   * This only makes sense if volumeType === VolumeType.SEGMENTATION.
-   */
-  getChunkedGraphUrl?: () => string | null;
 }

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -179,7 +179,7 @@ uint64_t getMappedObjectId() {
     let gl = this.gl;
 
     let {displayState} = this;
-    let {segmentSelectionState, visibleSegments2D} = this.displayState;
+    let {segmentSelectionState, rootSegments} = this.displayState;
     if (!segmentSelectionState.hasSelectedSegment) {
       selectedSegmentForShader.fill(0);
     } else {
@@ -193,7 +193,7 @@ uint64_t getMappedObjectId() {
     gl.uniform1f(shader.uniform('uSelectedAlpha'), this.displayState.selectedAlpha.value);
     gl.uniform1f(shader.uniform('uNotSelectedAlpha'), this.displayState.notSelectedAlpha.value);
     gl.uniform4fv(shader.uniform('uSelectedSegment'), selectedSegmentForShader);
-    gl.uniform1f(shader.uniform('uShowAllSegments'), visibleSegments2D!.hashTable.size ? 0.0 : 1.0);
+    gl.uniform1f(shader.uniform('uShowAllSegments'), rootSegments.hashTable.size ? 0.0 : 1.0);
     this.hashTableManager.enable(gl, shader, this.gpuHashTable);
     if (this.hasEquivalences) {
       this.equivalencesHashMap.update();

--- a/src/neuroglancer/uint64_set.ts
+++ b/src/neuroglancer/uint64_set.ts
@@ -22,7 +22,7 @@ import {registerRPC, registerSharedObject, RPC, SharedObjectCounterpart} from 'n
 @registerSharedObject('Uint64Set')
 export class Uint64Set extends SharedObjectCounterpart {
   hashTable = new HashSetUint64();
-  changed = new Signal<(x: Uint64 | null, add: boolean) => void>();
+  changed = new Signal<(x: Uint64 | Uint64[] | null, add: boolean) => void>();
 
   static makeWithCounterpart(rpc: RPC) {
     let obj = new Uint64Set();
@@ -36,15 +36,33 @@ export class Uint64Set extends SharedObjectCounterpart {
     this.changed = <any>undefined;
   }
 
-  add_(x: Uint64) {
-    return this.hashTable.add(x);
+  reserve_(x: number) {
+    return this.hashTable.reserve(x);
   }
 
-  add(x: Uint64) {
-    if (this.add_(x)) {
+  reserve(x: number) {
+    if (this.reserve_(x)) {
       let {rpc} = this;
       if (rpc) {
-        rpc.invoke('Uint64Set.add', {'id': this.rpcId, 'value': x});
+        rpc.invoke('Uint64Set.reserve', {'id': this.rpcId, 'value': x});
+      }
+    }
+  }
+
+  add_(x: Uint64[]) {
+    let changed = false;
+    for (const v of x) {
+      changed = this.hashTable.add(v) || changed;
+    }
+    return changed;
+  }
+
+  add(x: Uint64|Uint64[]) {
+    const tmp = Array<Uint64>().concat(x);
+    if (this.add_(tmp)) {
+      let {rpc} = this;
+      if (rpc) {
+        rpc.invoke('Uint64Set.add', {'id': this.rpcId, 'value': tmp});
       }
       this.changed.dispatch(x, true);
     }
@@ -58,15 +76,20 @@ export class Uint64Set extends SharedObjectCounterpart {
     return this.hashTable.keys();
   }
 
-  delete_(x: Uint64) {
-    return this.hashTable.delete(x);
+  delete_(x: Uint64[]) {
+    let changed = false;
+    for (const v of x) {
+      changed = this.hashTable.delete(v) || changed;
+    }
+    return changed;
   }
 
-  delete(x: Uint64) {
-    if (this.delete_(x)) {
+  delete(x: Uint64|Uint64[]) {
+    const tmp = Array<Uint64>().concat(x);
+    if (this.delete_(Array<Uint64>().concat(x))) {
       let {rpc} = this;
       if (rpc) {
-        rpc.invoke('Uint64Set.delete', {'id': this.rpcId, 'value': x});
+        rpc.invoke('Uint64Set.delete', {'id': this.rpcId, 'value': tmp});
       }
       this.changed.dispatch(x, false);
     }
@@ -96,6 +119,13 @@ export class Uint64Set extends SharedObjectCounterpart {
     return result;
   }
 }
+
+registerRPC('Uint64Set.reserve', function(x) {
+  let obj = this.get(x['id']);
+  if (obj.reserve_(x['value'])) {
+    obj.changed.dispatch();
+  }
+});
 
 registerRPC('Uint64Set.add', function(x) {
   let obj = this.get(x['id']);

--- a/src/neuroglancer/util/disjoint_sets.ts
+++ b/src/neuroglancer/util/disjoint_sets.ts
@@ -100,6 +100,12 @@ export class DisjointUint64Sets {
   private map = new Map<string, Uint64>();
   generation = 0;
 
+  has(x: Uint64): boolean {
+    let key = x.toString();
+    let element = this.map.get(key);
+    return element !== undefined;
+  }
+
   get(x: Uint64): Uint64 {
     let key = x.toString();
     let element = this.map.get(key);

--- a/src/neuroglancer/util/disjoint_sets.ts
+++ b/src/neuroglancer/util/disjoint_sets.ts
@@ -155,6 +155,7 @@ export class DisjointUint64Sets {
       for (const id of ids) {
         this.map.delete(id.toString());
       }
+      ++this.generation;
       return true;
     }
     return false;

--- a/src/neuroglancer/widget/segment_set_widget.ts
+++ b/src/neuroglancer/widget/segment_set_widget.ts
@@ -74,7 +74,7 @@ export class SegmentSetWidget extends RefCounted {
     clearButton.style.display = (this.displayState.rootSegments.size > 0) ? '' : 'none';
   }
 
-  private handleSetChanged(x: Uint64|null, added: boolean) {
+  private handleSetChanged(x: Uint64|Uint64[]|null, added: boolean) {
     this.updateClearButtonVisibility();
     let {items} = this;
     if (x === null) {
@@ -89,12 +89,16 @@ export class SegmentSetWidget extends RefCounted {
       }
       items.clear();
     } else if (added) {
-      this.addElement(x.toString());
+      for (const v of Array<Uint64>().concat(x)) {
+        this.addElement(v.toString());
+      }
     } else {
-      let s = x.toString();
-      let itemElement = items.get(s)!;
-      itemElement.parentElement!.removeChild(itemElement);
-      items.delete(s);
+      for (const v of Array<Uint64>().concat(x)) {
+        let s = v.toString();
+        let itemElement = items.get(s)!;
+        itemElement.parentElement!.removeChild(itemElement);
+        items.delete(s);
+      }
     }
   }
 


### PR DESCRIPTION
Calling the ChunkedGraph's getLeaves() function for visible chunks, only (instead of the whole dataset). Allows displaying huge objects without crashing the graphserver and/or neuroglancer.

TODO: Use bigger chunks when zooming out, only load "large" supervoxels