### PR TITLE
feat(sliceview): normalize source weight

### DIFF
--- a/src/neuroglancer/sliceview/base.ts
+++ b/src/neuroglancer/sliceview/base.ts
@@ -365,7 +365,7 @@ export class SliceViewBase extends SharedObject {
       scaleIndex = numSources - 1;
       while (true) {
         const transformedSource = pickBestAlternativeSource(zAxis, transformedSources[scaleIndex]);
-        addVisibleSource(transformedSource, scaleIndex);
+        addVisibleSource(transformedSource, (scaleIndex + 1) / numSources);
         if (scaleIndex === 0 || !canImproveOnVoxelSize(transformedSource.source.spec.voxelSize)) {
           break;
         }


### PR DESCRIPTION
Fixes https://github.com/seung-lab/neuroglancer/issues/191

Changes the absolute values for `scaleIndex`, which influence the priority for sliceview chunks, to a normalized version. Meaning that the lowest-resolution MIP maps of each layer are always loaded simultaneously, independent on _how many_ MIP maps those layers consist of.

