### PR TITLE
Ability to hide selected segments & to copy segment IDs

### DIFF
--- a/src/neuroglancer/segmentation_display_state/base.ts
+++ b/src/neuroglancer/segmentation_display_state/base.ts
@@ -27,6 +27,7 @@ export interface Bounds {
 
 export interface VisibleSegmentsStateWithoutClipBounds {
   rootSegments: Uint64Set;
+  hiddenRootSegments?: Uint64Set; // not needed for backend, for segment_set_widget.ts
   visibleSegments2D?: Uint64Set; // not needed for backend
   visibleSegments3D: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -78,6 +78,7 @@ export class SegmentationUserLayer extends Base {
         clipBounds: SharedWatchableValue.make<Bounds|undefined>(this.manager.worker, undefined),
         hideSegmentZero: new TrackableBoolean(true, true),
         rootSegments: Uint64Set.makeWithCounterpart(this.manager.worker),
+        hiddenRootSegments: new Uint64Set(),
         visibleSegments2D: new Uint64Set(),
         visibleSegments3D: Uint64Set.makeWithCounterpart(this.manager.worker),
         highlightedSegments: Uint64Set.makeWithCounterpart(this.manager.worker),

--- a/src/neuroglancer/ui/layer_side_panel.css
+++ b/src/neuroglancer/ui/layer_side_panel.css
@@ -15,7 +15,7 @@
  */
 
 .neuroglancer-layer-side-panel {
-  width: 290px;
+  width: 304px;
   margin-left: 3px;
   display: flex;
   flex-direction: column;

--- a/src/neuroglancer/ui/layer_side_panel.css
+++ b/src/neuroglancer/ui/layer_side_panel.css
@@ -15,7 +15,7 @@
  */
 
 .neuroglancer-layer-side-panel {
-  width: 304px;
+  width: 290px;
   margin-left: 3px;
   display: flex;
   flex-direction: column;

--- a/src/neuroglancer/widget/segment_set_widget.css
+++ b/src/neuroglancer/widget/segment_set_widget.css
@@ -16,6 +16,7 @@
 
 .segment-set-widget button {
   margin: 3px;
+  margin-right: 4px;
 }
 
 .segment-set-widget {

--- a/src/neuroglancer/widget/segment_set_widget.ts
+++ b/src/neuroglancer/widget/segment_set_widget.ts
@@ -31,7 +31,7 @@ export class SegmentSetWidget extends RefCounted {
   private itemContainer = document.createElement('div');
   private enabledItems = new Map<string, ItemElement>();
   private disabledItems = new Map<string, ItemElement>();
-  
+
   // A segment ID will only be a key in either the enabledItems
   // or the disableItems map, in which case it is displayed or
   // hidden in neuroglancer respectively (but in either case it
@@ -83,17 +83,20 @@ export class SegmentSetWidget extends RefCounted {
     this.updateClearButtonVisibility();
   }
 
-  private anyRootSegments = () => {
-    return this.displayState.rootSegments.size > 0;
-  }
+  private anyRootSegments =
+      () => {
+        return this.displayState.rootSegments.size > 0;
+      }
 
-  private anyHiddenRootSegments = () => {
-    return this.displayState.hiddenRootSegments!.size > 0;
-  }
+  private anyHiddenRootSegments =
+      () => {
+        return this.displayState.hiddenRootSegments!.size > 0;
+      }
 
   private updateClearButtonVisibility() {
     const {clearButton} = this;
-    clearButton.style.display = (this.anyRootSegments() || this.anyHiddenRootSegments()) ? '' : 'none';
+    clearButton.style.display =
+        (this.anyRootSegments() || this.anyHiddenRootSegments()) ? '' : 'none';
   }
 
   private clearItems() {
@@ -110,9 +113,10 @@ export class SegmentSetWidget extends RefCounted {
   }
 
   private handleEnabledSetChanged(x: Uint64|Uint64[]|null, added: boolean) {
+    this.updateClearButtonVisibility();
     const {enabledItems, disabledItems, hiddenRootSegments, anyHiddenRootSegments} = this;
     if (x === null) {
-      if (! anyHiddenRootSegments()) {
+      if (!anyHiddenRootSegments()) {
         // Cleared.
         this.clearItems();
       }
@@ -121,10 +125,9 @@ export class SegmentSetWidget extends RefCounted {
         const segmentIDString = segmentID.toString();
         const disabledItem = disabledItems.get(segmentIDString);
         // Make sure item not already added
-        if (! disabledItem) {
+        if (!disabledItem) {
           this.addElement(segmentIDString);
-        }
-        else {
+        } else {
           // Preparing to enable or disable an element
           enabledItems.set(segmentIDString, disabledItem);
           hiddenRootSegments!.delete(x);
@@ -135,7 +138,7 @@ export class SegmentSetWidget extends RefCounted {
       for (const segmentID of Array<Uint64>().concat(x)) {
         const segmentIDString = segmentID.toString();
         // Make sure item has been deleted, instead of disabled
-        if (! disabledItems.get(segmentIDString)) {
+        if (!disabledItems.get(segmentIDString)) {
           let itemElement = enabledItems.get(segmentIDString)!;
           itemElement.parentElement!.removeChild(itemElement);
         }
@@ -145,9 +148,10 @@ export class SegmentSetWidget extends RefCounted {
   }
 
   private handleDisabledSetChanged(x: Uint64|Uint64[]|null, added: boolean) {
-    const {enabledItems, disabledItems, rootSegments, anyRootSegments} = this; 
+    this.updateClearButtonVisibility();
+    const {enabledItems, disabledItems, rootSegments, anyRootSegments} = this;
     if (x === null) {
-      if (! anyRootSegments()) {
+      if (!anyRootSegments()) {
         // Cleared.
         this.clearItems();
       }
@@ -155,11 +159,11 @@ export class SegmentSetWidget extends RefCounted {
       for (const segmentID of Array<Uint64>().concat(x)) {
         const segmentIDString = segmentID.toString();
         const enabledItem = enabledItems.get(segmentIDString);
-        if (! enabledItem) {
+        if (!enabledItem) {
           // Should never happen
-          throw new Error('Erroneous attempt to hide a segment ID that does not exist in the widget');
-        }
-        else {
+          throw new Error(
+              'Erroneous attempt to hide a segment ID that does not exist in the widget');
+        } else {
           // Preparing to enable or disable an element
           disabledItems.set(segmentIDString, enabledItem);
           rootSegments.delete(x);
@@ -170,7 +174,7 @@ export class SegmentSetWidget extends RefCounted {
       for (const segmentID of Array<Uint64>().concat(x)) {
         const segmentIDString = segmentID.toString();
         // Make sure item has been deleted, instead of enabled
-        if (! enabledItems.get(segmentIDString)) {
+        if (!enabledItems.get(segmentIDString)) {
           let itemElement = disabledItems.get(segmentIDString)!;
           itemElement.parentElement!.removeChild(itemElement);
         }
@@ -179,14 +183,14 @@ export class SegmentSetWidget extends RefCounted {
     }
   }
 
-  private addElement(s: string) {
+  private addElement(segmentIDString: string) {
     // Wrap buttons in div so node button and its hide button appear on same line
     const itemElement = document.createElement('div');
     itemElement.className = 'segment-div';
     const itemButton = document.createElement('button');
     itemButton.className = 'segment-button';
-    itemButton.textContent = s;
-    itemButton.title = `Remove segment ID ${s}`;
+    itemButton.textContent = segmentIDString;
+    itemButton.title = `Remove segment ID ${segmentIDString}`;
     const widget = this;
     itemButton.addEventListener('click', function(this: HTMLButtonElement) {
       temp.tryParseString(this.textContent!);
@@ -203,14 +207,13 @@ export class SegmentSetWidget extends RefCounted {
     });
     const itemToggleButton = document.createElement('button');
     itemToggleButton.className = 'segment-toggle-button';
-    widget.setToggleButtonToHideSegment(itemToggleButton, s);
+    widget.setToggleButtonToHideSegment(itemToggleButton, segmentIDString);
     itemToggleButton.addEventListener('click', function(this: HTMLButtonElement) {
-      temp.tryParseString(s);
-      if (widget.enabledItems.get(s)) {
+      temp.tryParseString(segmentIDString);
+      if (widget.enabledItems.get(segmentIDString)) {
         // Add to hiddenRootSegments. handleSetChanged will delete segment from rootSegments
         widget.hiddenRootSegments!.add(temp);
-      }
-      else {
+      } else {
         // Add to rootSegments. handleSetChanged will delete segment from hiddenRootSegments
         widget.rootSegments.add(temp);
       }
@@ -218,11 +221,11 @@ export class SegmentSetWidget extends RefCounted {
     // Button for the user to copy a segment's ID
     const itemCopyIDButton = document.createElement('button');
     itemCopyIDButton.className = 'segment-copy-button';
-    itemCopyIDButton.title = `Copy segment ID ${s}`;
-    itemCopyIDButton.textContent = 'Copy ID';
+    itemCopyIDButton.title = `Copy segment ID ${segmentIDString}`;
+    itemCopyIDButton.textContent = '\u2702';
     itemCopyIDButton.addEventListener('click', function(this: HTMLButtonElement) {
       const handleCopy = (e: ClipboardEvent) => {
-        e.clipboardData.setData('text/plain', s);
+        e.clipboardData.setData('text/plain', segmentIDString);
         e.preventDefault();
         document.removeEventListener('copy', handleCopy);
         this.style.backgroundColor = 'rgb(0, 255, 0)';
@@ -240,11 +243,11 @@ export class SegmentSetWidget extends RefCounted {
     itemElement.appendChild(itemCopyIDButton);
     this.setItemButtonColor(itemElement);
     this.itemContainer.appendChild(itemElement);
-    this.enabledItems.set(s, itemElement);
+    this.enabledItems.set(segmentIDString, itemElement);
   }
 
   private setItemButtonColor(itemElement: ItemElement) {
-    const itemButton =  <HTMLElement>(itemElement.getElementsByClassName('segment-button')[0]);
+    const itemButton = <HTMLElement>(itemElement.getElementsByClassName('segment-button')[0]);
     temp.tryParseString(itemButton.textContent!);
     itemButton.style.backgroundColor = this.segmentColorHash.computeCssColor(temp);
   }
@@ -256,23 +259,31 @@ export class SegmentSetWidget extends RefCounted {
   }
 
   private setItemsToggleButtonToHideSegment(itemElement: ItemElement, segmentIDString: string) {
-    const itemToggleButton =  <HTMLButtonElement>(itemElement.getElementsByClassName('segment-toggle-button')[0]);
+    const itemToggleButton =
+        <HTMLButtonElement>(itemElement.getElementsByClassName('segment-toggle-button')[0]);
     this.setToggleButtonToHideSegment(itemToggleButton, segmentIDString);
   }
 
-  private setToggleButtonToHideSegment(itemToggleButton: HTMLButtonElement, segmentIDString: string) {
-    itemToggleButton.textContent = 'Hide segment';
+  private setToggleButtonToHideSegment(
+      itemToggleButton: HTMLButtonElement, segmentIDString: string) {
+    itemToggleButton.textContent = 'Hide';
     itemToggleButton.title = `Hide segment ID ${segmentIDString}`;
+    itemToggleButton.style.borderStyle = 'outset';
+    itemToggleButton.style.backgroundColor = 'rgb(240, 240, 240)';
   }
 
   private setItemsToggleButtonToShowSegment(itemElement: ItemElement, segmentIDString: string) {
-    const itemToggleButton =  <HTMLButtonElement>(itemElement.getElementsByClassName('segment-toggle-button')[0]);
+    const itemToggleButton =
+        <HTMLButtonElement>(itemElement.getElementsByClassName('segment-toggle-button')[0]);
     this.setToggleButtonToShowSegment(itemToggleButton, segmentIDString);
   }
 
-  private setToggleButtonToShowSegment(itemToggleButton: HTMLButtonElement, segmentIDString: string) {
-    itemToggleButton.textContent = 'Show segment';
+  private setToggleButtonToShowSegment(
+      itemToggleButton: HTMLButtonElement, segmentIDString: string) {
+    itemToggleButton.textContent = 'Show';
     itemToggleButton.title = `Show segment ID ${segmentIDString}`;
+    itemToggleButton.style.borderStyle = 'inset';
+    itemToggleButton.style.backgroundColor = 'rgb(210, 210, 210)';
   }
 
   disposed() {

--- a/src/neuroglancer/widget/segment_set_widget.ts
+++ b/src/neuroglancer/widget/segment_set_widget.ts
@@ -21,18 +21,29 @@ import {Uint64} from 'neuroglancer/util/uint64';
 require('neuroglancer/noselect.css');
 require('./segment_set_widget.css');
 
-type ItemElement = HTMLButtonElement;
+type ItemElement = HTMLDivElement;
 
-let temp = new Uint64();
+const temp = new Uint64();
 
 export class SegmentSetWidget extends RefCounted {
   element = document.createElement('div');
   private clearButton = document.createElement('button');
-  private itemContainer = document.createElement('span');
-  private items = new Map<string, ItemElement>();
+  private itemContainer = document.createElement('div');
+  private enabledItems = new Map<string, ItemElement>();
+  private disabledItems = new Map<string, ItemElement>();
+  
+  // disabledItems is a map to store the elements related to hidden segments.
+  // The following describes the relationship between a segment ID's existence in either
+  // of the above maps with its appearance in neuroglancer and its button in the widget:
+  // At any point, if a segment ID is in the enabledItems map, then it is in the widget
+  // and displayed in neuroglancer. If it is only in the disabledItems map, then it is only
+  // in the widget. If it is in neither, then it neither appears in neuroglancer nor in the widget.
 
   get rootSegments() {
     return this.displayState.rootSegments;
+  }
+  get hiddenRootSegments() {
+    return this.displayState.hiddenRootSegments;
   }
   get segmentColorHash() {
     return this.displayState.segmentColorHash;
@@ -43,12 +54,13 @@ export class SegmentSetWidget extends RefCounted {
 
   constructor(public displayState: SegmentationDisplayState) {
     super();
-    let {element, clearButton, itemContainer} = this;
+    const {element, clearButton, itemContainer} = this;
     element.className = 'segment-set-widget neuroglancer-noselect';
     clearButton.className = 'clear-button';
     clearButton.title = 'Remove all segment IDs';
     this.registerEventListener(clearButton, 'click', () => {
       this.rootSegments.clear();
+      this.hiddenRootSegments!.clear();
     });
 
     itemContainer.className = 'item-container';
@@ -57,7 +69,10 @@ export class SegmentSetWidget extends RefCounted {
     itemContainer.appendChild(clearButton);
 
     this.registerDisposer(displayState.rootSegments.changed.add((x, add) => {
-      this.handleSetChanged(x, add);
+      this.handleSetChanged(x, add, true);
+    }));
+    this.registerDisposer(displayState.hiddenRootSegments!.changed.add((x, add) => {
+      this.handleSetChanged(x, add, false);
     }));
     this.registerDisposer(displayState.segmentColorHash.changed.add(() => {
       this.handleColorChanged();
@@ -69,76 +84,182 @@ export class SegmentSetWidget extends RefCounted {
     this.updateClearButtonVisibility();
   }
 
-  private updateClearButtonVisibility() {
-    let {clearButton} = this;
-    clearButton.style.display = (this.displayState.rootSegments.size > 0) ? '' : 'none';
+  private anyRootSegments = () => {
+    return this.displayState.rootSegments.size > 0;
   }
 
-  private handleSetChanged(x: Uint64|Uint64[]|null, added: boolean) {
-    this.updateClearButtonVisibility();
-    let {items} = this;
-    if (x === null) {
-      // Cleared.
-      let {itemContainer, clearButton} = this;
-      while (true) {
-        let lastElement = itemContainer.lastElementChild!;
-        if (lastElement === clearButton) {
-          break;
-        }
-        itemContainer.removeChild(lastElement);
+  private anyHiddenRootSegments = () => {
+    return this.displayState.hiddenRootSegments!.size > 0;
+  }
+
+  private updateClearButtonVisibility() {
+    const {clearButton} = this;
+    clearButton.style.display = (this.anyRootSegments() || this.anyHiddenRootSegments()) ? '' : 'none';
+  }
+
+  private clearItems() {
+    const {itemContainer, clearButton, enabledItems, disabledItems} = this;
+    while (true) {
+      const lastElement = itemContainer.lastElementChild!;
+      if (lastElement === clearButton) {
+        break;
       }
-      items.clear();
+      itemContainer.removeChild(lastElement);
+    }
+    enabledItems.clear();
+    disabledItems.clear();
+  }
+
+  // The logic in handling each the displayed and the hidden segment set's changing is very similar,
+  // so we can combine the actions into one function.
+  private handleSetChanged(x: Uint64|Uint64[]|null, added: boolean, enabledSetChanged: boolean) {
+    const {enabledItems, disabledItems, anyRootSegments, anyHiddenRootSegments} = this;
+    const {itemMapToChange, otherItemMap, anySegmentsInUnchangedSet} = (enabledSetChanged) ?
+      {
+        itemMapToChange: enabledItems,
+        otherItemMap: disabledItems,
+        anySegmentsInUnchangedSet: anyHiddenRootSegments
+      } : {
+        itemMapToChange : disabledItems,
+        otherItemMap: enabledItems,
+        anySegmentsInUnchangedSet: anyRootSegments
+      };
+
+    if (x === null) {
+      // Make sure there aren't any items in other map before clearing
+      if (! anySegmentsInUnchangedSet()) {
+        // Cleared.
+        this.clearItems();
+      }
     } else if (added) {
       for (const v of Array<Uint64>().concat(x)) {
-        this.addElement(v.toString());
+        const s = v.toString();
+        const itemInOtherMap = otherItemMap.get(s);
+        // Make sure item not already added
+        if (! itemInOtherMap && enabledSetChanged) {
+          this.addElement(s);
+        }
+        else if (! itemInOtherMap) {
+          // Should never happen
+          throw new Error('Erroneous attempt to hide a segment ID that does not exist in the widget');
+        }
+        else {
+          // Preparing to enable or disable an element
+          itemMapToChange.set(s, itemInOtherMap);
+          if (enabledSetChanged) {
+            // Do this just in case root segment was enabled by clicking in neuroglancer as opposed to button
+            this.setItemsToggleButtonToHideSegment(itemInOtherMap, s);
+          }
+        }
       }
     } else {
       for (const v of Array<Uint64>().concat(x)) {
-        let s = v.toString();
-        let itemElement = items.get(s)!;
-        itemElement.parentElement!.removeChild(itemElement);
-        items.delete(s);
+        const s = v.toString();
+        // Make sure item has been deleted, instead of enabled or disabled
+        if (! otherItemMap.get(s)) {
+          let itemElement = itemMapToChange.get(s)!;
+          itemElement.parentElement!.removeChild(itemElement);
+        }
+        itemMapToChange.delete(s);
       }
     }
   }
 
   private addElement(s: string) {
-    let itemElement = document.createElement('button');
-    itemElement.className = 'segment-button';
-    itemElement.textContent = s;
-    itemElement.title = `Remove segment ID ${s}`;
-    let widget = this;
-    itemElement.addEventListener('click', function(this: ItemElement) {
+    // Wrap buttons in div so node button and its hide button appear on same line
+    const itemElement = document.createElement('div');
+    itemElement.className = 'segment-div';
+    const itemButton = document.createElement('button');
+    itemButton.className = 'segment-button';
+    itemButton.textContent = s;
+    itemButton.title = `Remove segment ID ${s}`;
+    const widget = this;
+    itemButton.addEventListener('click', function(this: HTMLButtonElement) {
       temp.tryParseString(this.textContent!);
       widget.rootSegments.delete(temp);
+      widget.hiddenRootSegments!.delete(temp);
     });
-    itemElement.addEventListener('mouseenter', function(this: ItemElement) {
+    itemButton.addEventListener('mouseenter', function(this: HTMLButtonElement) {
       temp.tryParseString(this.textContent!);
       widget.segmentSelectionState.set(temp);
     });
-    itemElement.addEventListener('mouseleave', function(this: ItemElement) {
+    itemButton.addEventListener('mouseleave', function(this: HTMLButtonElement) {
       temp.tryParseString(this.textContent!);
       widget.segmentSelectionState.set(null);
     });
-    this.setItemColor(itemElement);
+    const itemToggleButton = document.createElement('button');
+    itemToggleButton.className = 'segment-toggle-button';
+    widget.setToggleButtonToHideSegment(itemToggleButton, s);
+    itemToggleButton.addEventListener('click', function(this: HTMLButtonElement) {
+      temp.tryParseString(s);
+      if (widget.enabledItems.get(s)) {
+        // Add before delete so item is in at least one set
+        widget.hiddenRootSegments!.add(temp);
+        widget.rootSegments.delete(temp);
+        this.textContent = 'Show segment';
+        this.title = `Show segment ID ${s}`;
+      }
+      else {
+        // Add before delete again
+        widget.rootSegments.add(temp);
+        widget.hiddenRootSegments!.delete(temp);
+        widget.setToggleButtonToHideSegment(this, s);
+      }
+    });
+    // Button for the user to copy a segment's ID
+    const itemCopyIDButton = document.createElement('button');
+    itemCopyIDButton.className = 'segment-copy-button';
+    itemCopyIDButton.title = `Copy segment ID ${s}`;
+    itemCopyIDButton.textContent = 'Copy ID';
+    itemCopyIDButton.addEventListener('click', function(this: HTMLButtonElement) {
+      const handleCopy = (e: ClipboardEvent) => {
+        e.clipboardData.setData('text/plain', s);
+        e.preventDefault();
+        document.removeEventListener('copy', handleCopy);
+        this.style.backgroundColor = 'rgb(0, 255, 0)';
+        setTimeout(() => {
+          if (this.style.backgroundColor === 'rgb(0, 255, 0)') {
+            this.style.backgroundColor = 'rgb(240, 240, 240)';
+          }
+        }, 300);
+      }
+      document.addEventListener('copy', handleCopy);
+      document.execCommand('copy');
+    });
+    itemElement.appendChild(itemButton);
+    itemElement.appendChild(itemToggleButton);
+    itemElement.appendChild(itemCopyIDButton);
+    this.setItemButtonColor(itemElement);
     this.itemContainer.appendChild(itemElement);
-    this.items.set(s, itemElement);
+    this.enabledItems.set(s, itemElement);
   }
 
-  private setItemColor(itemElement: ItemElement) {
-    temp.tryParseString(itemElement.textContent!);
-    itemElement.style.backgroundColor = this.segmentColorHash.computeCssColor(temp);
+  private setItemButtonColor(itemElement: ItemElement) {
+    const itemButton =  <HTMLElement>(itemElement.getElementsByClassName('segment-button')[0]);
+    temp.tryParseString(itemButton.textContent!);
+    itemButton.style.backgroundColor = this.segmentColorHash.computeCssColor(temp);
   }
 
   private handleColorChanged() {
-    this.items.forEach(itemElement => {
-      this.setItemColor(itemElement);
+    this.enabledItems.forEach(itemElement => {
+      this.setItemButtonColor(itemElement);
     });
   }
 
+  private setItemsToggleButtonToHideSegment(itemElement: ItemElement, segmentIDString: string) {
+    const itemToggleButton =  <HTMLButtonElement>(itemElement.getElementsByClassName('segment-toggle-button')[0]);
+    this.setToggleButtonToHideSegment(itemToggleButton, segmentIDString);
+  }
+
+  // Made this function just to avoid doing this in several different places
+  private setToggleButtonToHideSegment(itemToggleButton: HTMLButtonElement, segmentIDString: string) {
+    itemToggleButton.textContent = 'Hide segment';
+    itemToggleButton.title = `Hide segment ID ${segmentIDString}`;
+  }
+
   disposed() {
-    let {element} = this;
-    let {parentElement} = element;
+    const {element} = this;
+    const {parentElement} = element;
     if (parentElement) {
       parentElement.removeChild(element);
     }

--- a/src/neuroglancer/widget/segment_set_widget.ts
+++ b/src/neuroglancer/widget/segment_set_widget.ts
@@ -234,7 +234,7 @@ export class SegmentSetWidget extends RefCounted {
             this.style.backgroundColor = 'rgb(240, 240, 240)';
           }
         }, 300);
-      }
+      };
       document.addEventListener('copy', handleCopy);
       document.execCommand('copy');
     });


### PR DESCRIPTION
Added two buttons to side panel to add ability for user to: (1) hide a
segment from the display without removing it from the side panel, and (2)
copy a segment ID to the clipboard.

Made the assumption that hidden segments should be known to the side
panel, and not stored in the URL, which may or may not be correct/best.

Edit: Pushed new commit that fixes bug @nkemnitz pointed out to me