### PR TITLE
Upgraded version of @types/jasmine in package.json to fix dependency problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "gulp": "gulp"
   },
   "devDependencies": {
-    "@types/jasmine": "^2.6.3",
+    "@types/jasmine": "^2.8.9",
     "babel-plugin-istanbul": "^4.1.5",
     "clang-format": "^1.1.0",
     "copy-webpack-plugin": "^4.5.1",
+    "event-stream": "^4.0.1",
     "gulp": "^3.9.1",
     "gulp-clang-format": "^1.0.23",
     "gulp-tslint": "^8.1.2",


### PR DESCRIPTION
Now able to run dev-server after building node_modules from scratch. FYI there are many npm packages in the package.json that are behind the version in google/neuroglancer, unsure of the importance of that