### PR TITLE
overlay click event listener

### DIFF
--- a/src/neuroglancer/overlay.ts
+++ b/src/neuroglancer/overlay.ts
@@ -47,6 +47,11 @@ export class Overlay extends RefCounted {
     this.registerEventListener(container, 'action:close', () => {
       this.dispose();
     });
+    container.onclick = (event) => {
+      if (event.target === container) {
+        this.dispose();
+      }
+    };
     content.focus();
   }
 


### PR DESCRIPTION
Resolves #259 
Simple fix - adding a listener to the overlay div directly, since the framework removes the div when overlay is closed there won't be any leaks. I feel anything more would be an overkill at this time.