### PR TITLE
refactor(chunked_graph/mesh): remove recursive missing mesh loading

### DIFF
--- a/src/neuroglancer/chunk_manager/base.ts
+++ b/src/neuroglancer/chunk_manager/base.ts
@@ -37,11 +37,9 @@ export enum ChunkState {
   EXPIRED = 7,
 
   COMPUTING = 8,
-
-  REQUESTING_CHILDREN = 9,
 }
 
-export const numChunkStates = 10;
+export const numChunkStates = 9;
 
 export enum ChunkPriorityTier {
   FIRST_TIER = 0,

--- a/src/neuroglancer/mesh/backend.ts
+++ b/src/neuroglancer/mesh/backend.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import debounce from 'lodash/debounce';
 import {Chunk, ChunkSource} from 'neuroglancer/chunk_manager/backend';
 import {ChunkPriorityTier, ChunkState} from 'neuroglancer/chunk_manager/base';
-import {ChunkedGraphLayer} from 'neuroglancer/sliceview/chunked_graph/backend';
 import {EncodedMeshData, FRAGMENT_SOURCE_RPC_ID, MESH_LAYER_RPC_ID, MULTISCALE_FRAGMENT_SOURCE_RPC_ID, MULTISCALE_MESH_LAYER_RPC_ID} from 'neuroglancer/mesh/base';
 import {getDesiredMultiscaleMeshChunks, MultiscaleMeshManifest} from 'neuroglancer/mesh/multiscale';
 import {computeTriangleStrips} from 'neuroglancer/mesh/triangle_strips';
 import {PerspectiveViewRenderLayer, PerspectiveViewState} from 'neuroglancer/perspective_view/backend';
 import {SegmentationLayerSharedObjectCounterpart} from 'neuroglancer/segmentation_display_state/backend';
 import {getObjectKey} from 'neuroglancer/segmentation_display_state/base';
-import {forEachRootSegment, forEachVisibleSegment3D} from 'neuroglancer/segmentation_display_state/base';
+import {forEachVisibleSegment3D} from 'neuroglancer/segmentation_display_state/base';
 import {WatchableSet} from 'neuroglancer/trackable_value';
 import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {convertEndian32, Endianness} from 'neuroglancer/util/endian';
@@ -37,7 +35,6 @@ import {registerSharedObject, RPC} from 'neuroglancer/worker_rpc';
 const MESH_OBJECT_MANIFEST_CHUNK_PRIORITY = 100;
 const MESH_OBJECT_FRAGMENT_CHUNK_PRIORITY = 50;
 
-const DEBUG = false;
 const CONVERT_TO_TRIANGLE_STRIPS = false;
 
 export type FragmentId = string;
@@ -75,12 +72,6 @@ export class ManifestChunk extends Chunk {
     if (this.priorityTier < ChunkPriorityTier.RECENT) {
       this.source!.chunkManager.scheduleUpdateChunkPriorities();
     }
-  }
-
-  downloadFailed(error: any) {
-    // Missing manifest means remeshing is in progress. Initiate loading of child chunks.
-    super.downloadFailed(error);
-    this.source!.chunkManager.scheduleUpdateChunkPriorities();
   }
 
   toString() {
@@ -396,12 +387,6 @@ export class FragmentSource extends ChunkSource {
 export class MeshLayer extends SegmentationLayerSharedObjectCounterpart implements
     PerspectiveViewRenderLayer {
   source: MeshSource;
-  chunkedGraph: ChunkedGraphLayer|null;
-  private requestedChildChunks: Map<string, { add: Uint64[], delete: Uint64[] }>;
-
-  private debouncedHandleChildChunks = debounce(() => {
-    this.handleChildChunks();
-  }, 100);
 
   viewStates = new WatchableSet<PerspectiveViewState>();
   private viewStatesDisposers = new Map<PerspectiveViewState, () => void>();
@@ -409,12 +394,9 @@ export class MeshLayer extends SegmentationLayerSharedObjectCounterpart implemen
   constructor(rpc: RPC, options: any) {
     super(rpc, options);
     this.source = this.registerDisposer(rpc.getRef<MeshSource>(options['source']));
-    this.chunkedGraph = this.registerDisposer(rpc.get(options['chunkedGraph'])) || null;
     this.registerDisposer(this.chunkManager.recomputeChunkPriorities.add(() => {
       this.updateChunkPriorities();
     }));
-
-    this.requestedChildChunks = new Map<string, { add: Uint64[], delete: Uint64[] }>();
 
     const scheduleUpdateChunkPriorities = () => {
       this.chunkManager.scheduleUpdateChunkPriorities();
@@ -445,25 +427,6 @@ export class MeshLayer extends SegmentationLayerSharedObjectCounterpart implemen
     });
   }
 
-  private handleChildChunks() {
-    for (const [rootId, elements] of this.requestedChildChunks.entries()) {
-      let rootTmp = Uint64.parseString(rootId);
-      if (!this.rootSegments.has(rootTmp)) {
-        console.log('Adding 3D children aborted due to missing root.');
-        continue;
-      }
-
-      for (let e of elements.add) {
-        this.visibleSegments3D.add(e);
-        this.segmentEquivalences.link(rootTmp, e);
-      }
-      for (let e of elements.delete) {
-        this.visibleSegments3D.delete(e);
-      }
-    }
-    this.requestedChildChunks.clear();
-  }
-
   private updateChunkPriorities() {
     const visibility = this.visibility.value;
     if (visibility === Number.NEGATIVE_INFINITY) {
@@ -472,53 +435,17 @@ export class MeshLayer extends SegmentationLayerSharedObjectCounterpart implemen
     const priorityTier = getPriorityTier(visibility);
     const basePriority = getBasePriority(visibility);
     const {source, chunkManager} = this;
-    forEachVisibleSegment3D(this, (objectId, rootObjectId) => {
+    forEachVisibleSegment3D(this, objectId => {
       let manifestChunk = source.getChunk(objectId);
       chunkManager.requestChunk(
           manifestChunk, priorityTier, basePriority + MESH_OBJECT_MANIFEST_CHUNK_PRIORITY);
       const state = manifestChunk.state;
-      switch(state) {
-        case ChunkState.SYSTEM_MEMORY_WORKER:
-        case ChunkState.SYSTEM_MEMORY:
-        case ChunkState.GPU_MEMORY: {
-          for (let fragmentId of manifestChunk.fragmentIds!) {
-            let fragmentChunk = source.getFragmentChunk(manifestChunk, fragmentId);
-            chunkManager.requestChunk(
-                fragmentChunk, priorityTier, basePriority + MESH_OBJECT_FRAGMENT_CHUNK_PRIORITY);
-          }
-          break;
-        }
-        case ChunkState.FAILED: {
-          if (this.chunkedGraph === null) {
-            break;
-          }
-          manifestChunk.state = ChunkState.REQUESTING_CHILDREN;
-          let segmentID = objectId.clone();
-          let rootID = rootObjectId.clone();
-          this.chunkedGraph.getChildren(objectId).then(children => {
-            if (DEBUG) { // with open 3D view, quickly select/deselect some segments
-              if (segmentID.low !== objectId.low || segmentID.high !== objectId.high) {
-                console.log(`SegmentID ${segmentID.toString()} does not match ObjectID ${objectId.toString()}`);
-              }
-              if (rootID.low !== rootObjectId.low || rootID.high !== rootObjectId.high) {
-                console.log(`RootID ${rootID.toString()} does not match RootObjectID ${rootObjectId.toString()}`);
-              }
-            }
-
-            manifestChunk.state = ChunkState.FAILED;
-            if (!this.rootSegments.has(rootID)) {
-              console.log('Adding 3D chunks aborted due to missing root object.');
-              return;
-            }
-            if (!this.requestedChildChunks.has(rootID.toString())) {
-              this.requestedChildChunks.set(rootID.toString(), { add: new Array<Uint64>(), delete: new Array<Uint64>() });
-            }
-            this.requestedChildChunks.get(rootID.toString())!.add.push(...children);
-            this.requestedChildChunks.get(rootID.toString())!.delete.push(segmentID);
-
-            this.debouncedHandleChildChunks();
-          });
-          break;
+      if (state === ChunkState.SYSTEM_MEMORY_WORKER || state === ChunkState.SYSTEM_MEMORY ||
+        state === ChunkState.GPU_MEMORY) {
+      for (let fragmentId of manifestChunk.fragmentIds!) {
+        let fragmentChunk = source.getFragmentChunk(manifestChunk, fragmentId);
+        chunkManager.requestChunk(
+            fragmentChunk, priorityTier, basePriority + MESH_OBJECT_FRAGMENT_CHUNK_PRIORITY);
         }
       }
     });
@@ -702,7 +629,7 @@ export class MultiscaleMeshLayer extends SegmentationLayerSharedObjectCounterpar
       const priorityTier = getPriorityTier(maxVisibility);
       const basePriority = getBasePriority(maxVisibility);
       const {source, chunkManager} = this;
-      forEachRootSegment(this, objectId => {
+      forEachVisibleSegment3D(this, objectId => {
         const manifestChunk = source.getChunk(objectId);
         chunkManager.requestChunk(
             manifestChunk, priorityTier, basePriority + MESH_OBJECT_MANIFEST_CHUNK_PRIORITY);

--- a/src/neuroglancer/mesh/frontend.ts
+++ b/src/neuroglancer/mesh/frontend.ts
@@ -16,11 +16,10 @@
 
 import {ChunkState} from 'neuroglancer/chunk_manager/base';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
-import {ChunkedGraphLayer} from 'neuroglancer/sliceview/chunked_graph/frontend';
 import {EncodedMeshData, FRAGMENT_SOURCE_RPC_ID, MESH_LAYER_RPC_ID, MULTISCALE_FRAGMENT_SOURCE_RPC_ID, MULTISCALE_MESH_LAYER_RPC_ID} from 'neuroglancer/mesh/base';
 import {getMultiscaleChunksToDraw, getMultiscaleFragmentKey, MultiscaleMeshManifest} from 'neuroglancer/mesh/multiscale';
 import {PerspectiveViewReadyRenderContext, PerspectiveViewRenderContext, PerspectiveViewRenderLayer} from 'neuroglancer/perspective_view/render_layer';
-import {forEachRootSegment, forEachVisibleSegment3D, getObjectKey} from 'neuroglancer/segmentation_display_state/base';
+import {forEachVisibleSegment3D, getObjectKey} from 'neuroglancer/segmentation_display_state/base';
 import {getObjectColor, registerRedrawWhenSegmentationDisplayState3DChanged, SegmentationDisplayState3D, SegmentationLayerSharedObject} from 'neuroglancer/segmentation_display_state/frontend';
 import {getFrustrumPlanes, mat3, mat3FromMat4, mat4, vec3, vec4} from 'neuroglancer/util/geom';
 import {getObjectId} from 'neuroglancer/util/object_id';
@@ -180,9 +179,7 @@ export class MeshLayer extends PerspectiveViewRenderLayer {
   backend: SegmentationLayerSharedObject;
 
   constructor(
-      public chunkManager: ChunkManager,
-      public chunkedGraph: ChunkedGraphLayer|null,
-      public source: MeshSource,
+      public chunkManager: ChunkManager, public source: MeshSource,
       public displayState: SegmentationDisplayState3D) {
     super();
 
@@ -193,7 +190,6 @@ export class MeshLayer extends PerspectiveViewRenderLayer {
     sharedObject.RPC_TYPE_ID = MESH_LAYER_RPC_ID;
     sharedObject.initializeCounterpartWithChunkManager({
       'source': source.addCounterpartRef(),
-      'chunkedGraph': chunkedGraph ? chunkedGraph.rpcId : null,
     });
     this.setReady(true);
     sharedObject.visibility.add(this.visibility);
@@ -371,9 +367,7 @@ export class MultiscaleMeshLayer extends PerspectiveViewRenderLayer {
   backend: SegmentationLayerSharedObject;
 
   constructor(
-      public chunkManager: ChunkManager,
-      public chunkedGraph: ChunkedGraphLayer|null,
-      public source: MultiscaleMeshSource,
+      public chunkManager: ChunkManager, public source: MultiscaleMeshSource,
       public displayState: SegmentationDisplayState3D) {
     super();
 
@@ -514,7 +508,7 @@ export class MultiscaleMeshLayer extends PerspectiveViewRenderLayer {
 
     let hasAllChunks = true;
 
-    forEachRootSegment(displayState, (objectId) => {
+    forEachVisibleSegment3D(displayState, (objectId) => {
       if (!hasAllChunks) {
         return;
       }

--- a/src/neuroglancer/segmentation_display_state/base.ts
+++ b/src/neuroglancer/segmentation_display_state/base.ts
@@ -35,27 +35,15 @@ export function getObjectKey(objectId: Uint64): string {
 }
 
 export function forEachRootSegment(
-    state: VisibleSegmentsState,
-    callback: (rootObjectId: Uint64) => void) {
+    state: VisibleSegmentsState, callback: (rootObjectId: Uint64) => void) {
   let {rootSegments} = state;
   for (let rootObjectId of rootSegments) {
     callback(rootObjectId);
   }
 }
 
-export function forEachVisibleSegment2D(
-    state: VisibleSegmentsState,
-    callback: (objectId: Uint64, rootObjectId: Uint64) => void) {
-  let {visibleSegments2D, segmentEquivalences} = state;
-  for (let objectId of visibleSegments2D!) {
-    let rootObjectId = segmentEquivalences.get(objectId);
-    callback(objectId, rootObjectId);
-  }
-}
-
 export function forEachVisibleSegment3D(
-    state: VisibleSegmentsState,
-    callback: (objectId: Uint64, rootObjectId: Uint64) => void) {
+    state: VisibleSegmentsState, callback: (objectId: Uint64, rootObjectId: Uint64) => void) {
   let {visibleSegments3D, segmentEquivalences} = state;
   for (let objectId of visibleSegments3D) {
     let rootObjectId = segmentEquivalences.get(objectId);

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -256,7 +256,7 @@ export class SegmentationUserLayer extends Base {
               }
               if ((meshSource instanceof MeshSource) ||
                   (meshSource instanceof MultiscaleMeshSource)) {
-                this.addMesh(meshSource, this.chunkedGraphLayer);
+                this.addMesh(meshSource);
                 this.objectLayerStateChanged.dispatch();
               }
             });
@@ -274,7 +274,7 @@ export class SegmentationUserLayer extends Base {
                 this.isReady = true;
               }
               if (skeletonSource) {
-                this.addSkeleton(skeletonSource, this.chunkedGraphLayer);
+                this.addSkeleton(skeletonSource);
                 this.objectLayerStateChanged.dispatch();
               }
             });
@@ -287,19 +287,19 @@ export class SegmentationUserLayer extends Base {
     }
   }
 
-  addMesh(meshSource: MeshSource|MultiscaleMeshSource, chunkedGraph?: ChunkedGraphLayer) {
+  addMesh(meshSource: MeshSource|MultiscaleMeshSource) {
     if (meshSource instanceof MeshSource) {
-      this.meshLayer = new MeshLayer(this.manager.chunkManager, chunkedGraph ? chunkedGraph : null, meshSource, this.displayState);
+      this.meshLayer = new MeshLayer(this.manager.chunkManager, meshSource, this.displayState);
     } else {
       this.meshLayer =
-          new MultiscaleMeshLayer(this.manager.chunkManager, chunkedGraph ? chunkedGraph : null, meshSource, this.displayState);
+          new MultiscaleMeshLayer(this.manager.chunkManager, meshSource, this.displayState);
     }
     this.addRenderLayer(this.meshLayer);
   }
 
-  addSkeleton(skeletonSource: SkeletonSource, chunkedGraph?: ChunkedGraphLayer) {
+  addSkeleton(skeletonSource: SkeletonSource) {
     let base = new SkeletonLayer(
-        this.manager.chunkManager, chunkedGraph ? chunkedGraph : null, skeletonSource, this.manager.voxelSize, this.displayState);
+        this.manager.chunkManager, skeletonSource, this.manager.voxelSize, this.displayState);
     this.skeletonLayer = base;
     this.addRenderLayer(new PerspectiveViewSkeletonLayer(base.addRef()));
     this.addRenderLayer(new SliceViewPanelSkeletonLayer(/* transfer ownership */ base));

--- a/src/neuroglancer/skeleton/backend.ts
+++ b/src/neuroglancer/skeleton/backend.ts
@@ -15,10 +15,9 @@
  */
 
 import {Chunk, ChunkSource} from 'neuroglancer/chunk_manager/backend';
-import {ChunkedGraphLayer} from 'neuroglancer/sliceview/chunked_graph/backend';
 import {decodeVertexPositionsAndIndices} from 'neuroglancer/mesh/backend';
 import {SegmentationLayerSharedObjectCounterpart} from 'neuroglancer/segmentation_display_state/backend';
-import {forEachRootSegment, getObjectKey} from 'neuroglancer/segmentation_display_state/base';
+import {forEachVisibleSegment3D, getObjectKey} from 'neuroglancer/segmentation_display_state/base';
 import {SKELETON_LAYER_RPC_ID} from 'neuroglancer/skeleton/base';
 import {TypedArray} from 'neuroglancer/util/array';
 import {Endianness} from 'neuroglancer/util/endian';
@@ -114,12 +113,10 @@ export class SkeletonSource extends ChunkSource {
 @registerSharedObject(SKELETON_LAYER_RPC_ID)
 export class SkeletonLayer extends SegmentationLayerSharedObjectCounterpart {
   source: SkeletonSource;
-  chunkedGraph: ChunkedGraphLayer | null;
 
   constructor(rpc: RPC, options: any) {
     super(rpc, options);
     this.source = this.registerDisposer(rpc.getRef<SkeletonSource>(options['source']));
-    this.chunkedGraph = this.registerDisposer(rpc.get(options['chunkedGraph']));
     this.registerDisposer(this.chunkManager.recomputeChunkPriorities.add(() => {
       this.updateChunkPriorities();
     }));
@@ -133,7 +130,7 @@ export class SkeletonLayer extends SegmentationLayerSharedObjectCounterpart {
     const priorityTier = getPriorityTier(visibility);
     const basePriority = getBasePriority(visibility);
     const {source, chunkManager} = this;
-    forEachRootSegment(this, objectId => {
+    forEachVisibleSegment3D(this, objectId => {
       const chunk = source.getChunk(objectId);
       chunkManager.requestChunk(chunk, priorityTier, basePriority + SKELETON_CHUNK_PRIORITY);
     });

--- a/src/neuroglancer/skeleton/frontend.ts
+++ b/src/neuroglancer/skeleton/frontend.ts
@@ -16,7 +16,6 @@
 
 import {ChunkState} from 'neuroglancer/chunk_manager/base';
 import {Chunk, ChunkManager, ChunkSource} from 'neuroglancer/chunk_manager/frontend';
-import {ChunkedGraphLayer} from 'neuroglancer/sliceview/chunked_graph/frontend';
 import {RenderLayer} from 'neuroglancer/layer';
 import {VoxelSize} from 'neuroglancer/navigation_state';
 import {PerspectiveViewRenderContext, PerspectiveViewRenderLayer} from 'neuroglancer/perspective_view/render_layer';
@@ -172,11 +171,8 @@ export class SkeletonLayer extends RefCounted {
   }
 
   constructor(
-      public chunkManager: ChunkManager,
-      public chunkedGraph: ChunkedGraphLayer|null,
-      public source: SkeletonSource,
-      public voxelSizeObject: VoxelSize,
-      public displayState: SkeletonLayerDisplayState) {
+      public chunkManager: ChunkManager, public source: SkeletonSource,
+      public voxelSizeObject: VoxelSize, public displayState: SkeletonLayerDisplayState) {
     super();
 
     registerRedrawWhenSegmentationDisplayState3DChanged(displayState, this);
@@ -190,7 +186,6 @@ export class SkeletonLayer extends RefCounted {
     sharedObject.RPC_TYPE_ID = SKELETON_LAYER_RPC_ID;
     sharedObject.initializeCounterpartWithChunkManager({
       'source': source.addCounterpartRef(),
-      'chunkedGraph': chunkedGraph ? chunkedGraph.rpcId : null,
     });
 
     const vertexAttributes = this.vertexAttributes = [vertexPositionAttribute];
@@ -271,7 +266,7 @@ export class SkeletonLayer extends RefCounted {
 
     gl.lineWidth(lineWidth);
 
-    forEachVisibleSegment3D(displayState, (rootObjectId, objectId) => {
+    forEachVisibleSegment3D(displayState, (objectId, rootObjectId) => {
       const key = getObjectKey(objectId);
       const skeleton = skeletons.get(key);
 


### PR DESCRIPTION
Now that the graph server always returns the mesh manifest files including only existing meshes, we don't have to play ping-pong between Neuroglancer, GCS and the graph server anymore to recursively load missing meshes.
Makes mesh loading a bit more predictable / easier to follow, and we don't have to carry around the graph server within the mesh and skeleton backend.

Also found some bugs related to rootSegment <-> visibleSegment3D. Most of the time they refer to the same segments. Except for when users play with segment equivalences in a non-graph-server dataset.