### PR TITLE
change mouse action

### DIFF
--- a/src/neuroglancer/overlay.ts
+++ b/src/neuroglancer/overlay.ts
@@ -47,7 +47,7 @@ export class Overlay extends RefCounted {
     this.registerEventListener(container, 'action:close', () => {
       this.dispose();
     });
-    container.onclick = (event) => {
+    container.onmousedown = (event) => {
       if (event.target === container) {
         this.dispose();
       }


### PR DESCRIPTION
When mouse click starts inside the overlay and ends outside (for eg. select all in state editor), it is unexpectedly closed. Using mousedown in place of click event avoids that.