### PR TITLE
compat(graphene): force upgrade to segmentation_with_graph

### DIFF
--- a/src/neuroglancer/layer_specification.ts
+++ b/src/neuroglancer/layer_specification.ts
@@ -169,6 +169,16 @@ export class TopLevelLayerListSpecification extends RefCounted implements LayerL
     };
     let sourceUrl = managedLayer.sourceUrl =
         verifyObjectProperty(spec, 'source', verifyOptionalString);
+
+    // Compatibility for old graphene links with type: `segmentation`
+    if (sourceUrl !== undefined &&
+        this.dataSourceProvider.getDataSource(sourceUrl)[2] === 'graphene' &&
+        layerType === 'segmentation') {
+      spec['type'] = layerType = 'segmentation_with_graph';
+      StatusMessage.showMessage(`The layer specification for ${
+          sourceUrl} is deprecated. Key 'layerType' must be 'segmentation_with_graph'. Please reload this page.`);
+    }
+
     if (layerType === undefined) {
       if (sourceUrl === undefined) {
         throw new Error(`Either layer 'type' or 'source' URL must be specified.`);


### PR DESCRIPTION
Not a fan of this, but it makes existing links that are floating around work with the new `segmentation_user_layer_with_graph`.
Hopefully we can keep this a temporary change...