### PR TITLE
Flexible group widgets for cluttered user layers

### DIFF
--- a/src/neuroglancer/annotation/user_layer.ts
+++ b/src/neuroglancer/annotation/user_layer.ts
@@ -206,7 +206,7 @@ export class AnnotationUserLayer extends Base {
     const widget = tab.registerDisposer(new LayerReferenceWidget(this.linkedSegmentationLayer));
     widget.element.insertBefore(
         document.createTextNode('Linked segmentation: '), widget.element.firstChild);
-    tab.element.appendChild(widget.element);
+    tab.groupVisualization.appendFixedChild(widget.element);
 
     {
       const checkboxWidget = this.registerDisposer(
@@ -214,7 +214,7 @@ export class AnnotationUserLayer extends Base {
       const label = document.createElement('label');
       label.textContent = 'Filter by segmentation: ';
       label.appendChild(checkboxWidget.element);
-      tab.element.appendChild(label);
+      tab.groupVisualization.appendFixedChild(label);
       tab.registerDisposer(new ElementVisibilityFromTrackableBoolean(
           this.registerDisposer(makeDerivedWatchableValue(
               v => v !== undefined, tab.annotationLayer.segmentationState)),

--- a/src/neuroglancer/image_user_layer.ts
+++ b/src/neuroglancer/image_user_layer.ts
@@ -23,6 +23,7 @@ import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {trackableBlendModeValue} from 'neuroglancer/trackable_blend';
 import {UserLayerWithVolumeSourceMixin} from 'neuroglancer/user_layer_with_volume_source';
 import {makeWatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {RangeWidget} from 'neuroglancer/widget/range';
 import {RenderScaleWidget} from 'neuroglancer/widget/render_scale_widget';
 import {ShaderCodeWidget} from 'neuroglancer/widget/shader_code_widget';
@@ -96,11 +97,12 @@ function makeShaderCodeWidget(layer: ImageUserLayer) {
 }
 
 class RenderingOptionsTab extends Tab {
+  private group2D = this.registerDisposer(new MinimizableGroupWidget('2D Visualization'));
   opacityWidget = this.registerDisposer(new RangeWidget(this.layer.opacity));
   codeWidget = this.registerDisposer(makeShaderCodeWidget(this.layer));
   constructor(public layer: ImageUserLayer) {
     super();
-    const {element} = this;
+    const {group2D, element} = this;
     element.classList.add('image-dropdown');
     let {opacityWidget} = this;
     let topRow = document.createElement('div');
@@ -111,7 +113,7 @@ class RenderingOptionsTab extends Tab {
       const renderScaleWidget = this.registerDisposer(new RenderScaleWidget(
           this.layer.sliceViewRenderScaleHistogram, this.layer.sliceViewRenderScaleTarget));
       renderScaleWidget.label.textContent = 'Resolution (slice)';
-      element.appendChild(renderScaleWidget.element);
+      group2D.appendFixedChild(renderScaleWidget.element);
     }
 
     let spacer = document.createElement('div');
@@ -140,9 +142,11 @@ class RenderingOptionsTab extends Tab {
     topRow.appendChild(maximizeButton);
     topRow.appendChild(helpLink);
 
-    element.appendChild(topRow);
-    element.appendChild(this.codeWidget.element);
+    group2D.appendFixedChild(topRow);
+    group2D.appendFlexibleChild(this.codeWidget.element);
+    element.appendChild(group2D.element);
     this.codeWidget.textEditor.refresh();
+
     this.visibility.changed.add(() => {
       if (this.visible) {
         this.codeWidget.textEditor.refresh();

--- a/src/neuroglancer/single_mesh_user_layer.ts
+++ b/src/neuroglancer/single_mesh_user_layer.ts
@@ -25,6 +25,7 @@ import {UserLayerWithCoordinateTransformMixin} from 'neuroglancer/user_layer_wit
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {removeFromParent} from 'neuroglancer/util/dom';
 import {parseArray, verifyObjectProperty, verifyOptionalString, verifyString} from 'neuroglancer/util/json';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {ShaderCodeWidget} from 'neuroglancer/widget/shader_code_widget';
 import {Tab} from 'neuroglancer/widget/tab_view';
 
@@ -263,11 +264,12 @@ function makeVertexAttributeWidget(layer: SingleMeshUserLayer) {
 }
 
 class DisplayOptionsTab extends Tab {
+  private group3D = this.registerDisposer(new MinimizableGroupWidget('3D Visualization'));
   attributeWidget = this.registerDisposer(makeVertexAttributeWidget(this.layer));
   codeWidget = this.registerDisposer(makeShaderCodeWidget(this.layer));
   constructor(public layer: SingleMeshUserLayer) {
     super();
-    const {element} = this;
+    const {group3D, element} = this;
     element.classList.add('neuroglancer-single-mesh-dropdown');
     let topRow = document.createElement('div');
     topRow.className = 'neuroglancer-single-mesh-dropdown-top-row';
@@ -296,9 +298,10 @@ class DisplayOptionsTab extends Tab {
     topRow.appendChild(maximizeButton);
     topRow.appendChild(helpLink);
 
-    element.appendChild(topRow);
-    element.appendChild(this.attributeWidget.element);
-    element.appendChild(this.codeWidget.element);
+    group3D.appendFixedChild(topRow);
+    group3D.appendFixedChild(this.attributeWidget.element);
+    group3D.appendFlexibleChild(this.codeWidget.element);
+    element.appendChild(group3D.element);
     this.codeWidget.textEditor.refresh();
 
     this.visibility.changed.add(() => {

--- a/src/neuroglancer/ui/annotations.css
+++ b/src/neuroglancer/ui/annotations.css
@@ -26,9 +26,7 @@
   margin: 0px;
   padding: 5px;
   overflow-y: auto;
-  height: 0px;
   flex: 1;
-  flex-basis: 0px;
   min-height: 0px;
 }
 

--- a/src/neuroglancer/ui/annotations.ts
+++ b/src/neuroglancer/ui/annotations.ts
@@ -42,6 +42,7 @@ import {Uint64} from 'neuroglancer/util/uint64';
 import {WatchableVisibilityPriority} from 'neuroglancer/visibility_priority/frontend';
 import {makeCloseButton} from 'neuroglancer/widget/close_button';
 import {ColorWidget} from 'neuroglancer/widget/color';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {RangeWidget} from 'neuroglancer/widget/range';
 import {StackView, Tab} from 'neuroglancer/widget/tab_view';
 import {makeTextIconButton} from 'neuroglancer/widget/text_icon_button';
@@ -379,6 +380,8 @@ export class AnnotationLayerView extends Tab {
   private previousSelectedId: string|undefined;
   private previousHoverId: string|undefined;
   private updated = false;
+  groupVisualization = this.registerDisposer(new MinimizableGroupWidget('Visualization'));
+  groupAnnotations = this.registerDisposer(new MinimizableGroupWidget('Annotations'));
 
   constructor(
       public layer: Borrowed<UserLayerWithAnnotations>,
@@ -412,7 +415,7 @@ export class AnnotationLayerView extends Tab {
     {
       const widget = this.registerDisposer(new RangeWidget(this.annotationLayer.fillOpacity));
       widget.promptElement.textContent = 'Fill opacity';
-      this.element.appendChild(widget.element);
+      this.groupVisualization.appendFixedChild(widget.element);
     }
 
     const colorPicker = this.registerDisposer(new ColorWidget(this.annotationLayer.color));
@@ -455,7 +458,6 @@ export class AnnotationLayerView extends Tab {
       });
       toolbox.appendChild(ellipsoidButton);
     }
-    this.element.appendChild(toolbox);
 
     {
       const jumpingShowsSegmentationCheckbox = this.registerDisposer(
@@ -463,7 +465,7 @@ export class AnnotationLayerView extends Tab {
       const label = document.createElement('label');
       label.textContent = 'Bracket shortcuts show segmentation: ';
       label.appendChild(jumpingShowsSegmentationCheckbox.element);
-      this.element.appendChild(label);
+      this.groupVisualization.appendFixedChild(label);
     }
 
     {
@@ -507,7 +509,7 @@ export class AnnotationLayerView extends Tab {
       const label = document.createElement('label');
       label.textContent = 'Filter annotation list by tag: ';
       label.appendChild(annotationTagFilter);
-      this.element.appendChild(label);
+      this.groupVisualization.appendFixedChild(label);
     }
 
     {
@@ -517,10 +519,13 @@ export class AnnotationLayerView extends Tab {
       exportToCSVButton.addEventListener('click', () => {
         this.exportToCSV();
       });
-      this.element.appendChild(exportToCSVButton);
+      this.groupAnnotations.appendFixedChild(exportToCSVButton);
     }
 
-    this.element.appendChild(this.annotationListContainer);
+    this.groupAnnotations.appendFixedChild(toolbox);
+    this.groupAnnotations.appendFlexibleChild(this.annotationListContainer);
+    this.element.appendChild(this.groupVisualization.element);
+    this.element.appendChild(this.groupAnnotations.element);
 
     this.annotationListContainer.addEventListener('mouseleave', () => {
       this.annotationLayer.hoverState.value = undefined;

--- a/src/neuroglancer/ui/graph.css
+++ b/src/neuroglancer/ui/graph.css
@@ -14,10 +14,31 @@
  * limitations under the License.
  */
 
- .neuroglancer-graphoperation-toolbox {
-    display: flex;
-  }
-  
-  .neuroglancer-graphoperation-toolbox button {
-    width: 100%;
-  }
+.neuroglancer-graphoperations-tab {
+  display: flex;
+  align-items: stretch;
+  flex: 1;
+  flex-direction: column;
+}
+
+.neuroglancer-graphoperations-list {
+  list-style-type: none;
+  margin: 0px;
+  padding: 5px;
+  overflow-y: auto;
+  flex: none;
+}
+
+.neuroglancer-graphoperations-list > li {
+  cursor: pointer;
+  position: relative;
+  padding-left: 1.5em;
+}
+
+.neuroglancer-graphoperation-toolbox {
+  display: flex;
+}
+
+.neuroglancer-graphoperation-toolbox button {
+   width: 100%;
+}

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -28,6 +28,7 @@ import {GraphOperationLayerState} from 'neuroglancer/graph/graph_operation_layer
 import {MouseSelectionState} from 'neuroglancer/layer';
 import {VoxelSize} from 'neuroglancer/navigation_state';
 import {SegmentationDisplayState} from 'neuroglancer/segmentation_display_state/frontend';
+import {SegmentationUserLayerWithGraph} from 'neuroglancer/segmentation_user_layer_with_graph';
 import {SegmentSelection} from 'neuroglancer/sliceview/chunked_graph/frontend';
 import {StatusMessage} from 'neuroglancer/status';
 import {WatchableRefCounted, WatchableValue} from 'neuroglancer/trackable_value';
@@ -41,9 +42,9 @@ import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {WatchableVisibilityPriority} from 'neuroglancer/visibility_priority/frontend';
 import {makeCloseButton} from 'neuroglancer/widget/close_button';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {StackView, Tab} from 'neuroglancer/widget/tab_view';
 import {makeTextIconButton} from 'neuroglancer/widget/text_icon_button';
-import {SegmentationUserLayerWithGraph} from '../segmentation_user_layer_with_graph';
 
 type GraphOperationMarkerId = {
   id: string,
@@ -273,6 +274,7 @@ export class GraphOperationLayerView extends Tab {
   private previousSelectedId: string|undefined;
   private previousHoverId: string|undefined;
   private updated = false;
+  multicutGroup = this.registerDisposer(new MinimizableGroupWidget('Multicut'));
 
   constructor(
       public wrapper: Borrowed<SegmentationUserLayerWithGraph>,
@@ -281,7 +283,7 @@ export class GraphOperationLayerView extends Tab {
       public setSpatialCoordinates: (point: vec3) => void) {
     super();
     this.element.classList.add('neuroglancer-annotation-layer-view');
-    this.annotationListContainer.classList.add('neuroglancer-annotation-list');
+    this.annotationListContainer.classList.add('neuroglancer-graphoperations-list');
     this.registerDisposer(state);
     this.registerDisposer(voxelSize);
     this.registerDisposer(annotationLayer);
@@ -388,10 +390,9 @@ export class GraphOperationLayerView extends Tab {
       toolbox.appendChild(cancelButton);
     }
 
-
-    this.element.appendChild(toolbox);
-
-    this.element.appendChild(this.annotationListContainer);
+    this.multicutGroup.appendFixedChild(toolbox);
+    this.multicutGroup.appendFlexibleChild(this.annotationListContainer);
+    this.element.appendChild(this.multicutGroup.element);
 
     this.annotationListContainer.addEventListener('mouseleave', () => {
       this.annotationLayer.hoverState.value = undefined;
@@ -647,8 +648,9 @@ export class GraphOperationTab extends Tab {
     this.registerDisposer(state);
     this.registerDisposer(voxelSize);
     const {element} = this;
-    element.classList.add('neuroglancer-annotations-tab');
+    element.classList.add('neuroglancer-graphoperations-tab');
     this.stack.element.classList.add('neuroglancer-annotations-stack');
+
     element.appendChild(this.stack.element);
     element.appendChild(this.detailsTab.element);
     const updateDetailsVisibility = () => {

--- a/src/neuroglancer/vector_graphics_user_layer.ts
+++ b/src/neuroglancer/vector_graphics_user_layer.ts
@@ -27,6 +27,7 @@ import {trackableFiniteFloat} from 'neuroglancer/trackable_finite_float';
 import {trackableVec3, TrackableVec3} from 'neuroglancer/trackable_vec3';
 import {vec3} from 'neuroglancer/util/geom';
 import {verifyEnumString, verifyFiniteFloat, verifyOptionalString} from 'neuroglancer/util/json';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {RangeWidget} from 'neuroglancer/widget/range';
 import {Tab} from 'neuroglancer/widget/tab_view';
 import {Vec3Widget} from 'neuroglancer/widget/vec3_entry_widget';
@@ -117,6 +118,8 @@ export class VectorGraphicsUserLayer extends UserLayer {
 }
 
 class DisplayOptionsTab extends Tab {
+  private groupVisualization =
+      this.registerDisposer(new MinimizableGroupWidget('3D Visualization'));
   opacityWidget = this.registerDisposer(new RangeWidget(this.layer.opacity));
   lineWidthWidget =
       this.registerDisposer(new RangeWidget(this.layer.lineWidth, {min: 0, max: 50, step: 1}));
@@ -124,7 +127,7 @@ class DisplayOptionsTab extends Tab {
 
   constructor(public layer: VectorGraphicsUserLayer) {
     super();
-    const {element} = this;
+    const {groupVisualization, element} = this;
     element.classList.add('image-dropdown');
     let {opacityWidget, lineWidthWidget, colorWidget} = this;
     let topRow = document.createElement('div');
@@ -149,10 +152,11 @@ class DisplayOptionsTab extends Tab {
     topRow.appendChild(spacer);
     topRow.appendChild(helpLink);
 
-    element.appendChild(topRow);
-    element.appendChild(this.opacityWidget.element);
-    element.appendChild(this.lineWidthWidget.element);
-    element.appendChild(this.colorWidget.element);
+    groupVisualization.appendFixedChild(topRow);
+    groupVisualization.appendFixedChild(this.opacityWidget.element);
+    groupVisualization.appendFixedChild(this.lineWidthWidget.element);
+    groupVisualization.appendFixedChild(this.colorWidget.element);
+    element.appendChild(groupVisualization.element);
   }
 }
 

--- a/src/neuroglancer/widget/minimizable_group.css
+++ b/src/neuroglancer/widget/minimizable_group.css
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2019 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+.neuroglancer-minimizable-group {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: hidden;
+  max-height: max-content;
+}
+
+.neuroglancer-minimizable-group-title {
+  flex: none;
+  cursor: pointer;
+  font: 10pt sans-serif;
+  color: #aaa;
+  font-weight: bold;
+  padding: 2px 0px 4px 4px;
+  box-sizing: content-box;
+  background-color: #333;
+}
+
+.neuroglancer-minimizable-group-title::before {
+  content: '⮟ ';
+}
+
+.neuroglancer-minimizable-group-title.minimized::before {
+  content: '➤ ';
+}
+
+.neuroglancer-minimizable-group-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: auto;
+  max-height: max-content;
+}
+
+.neuroglancer-minimizable-group-content.minimized {
+  display: none;
+}
+
+.neuroglancer-minimizable-group-fixed {
+  flex: none;
+}
+
+.neuroglancer-minimizable-group-flexible {
+  flex: 0 1 auto;
+  overflow-y: auto;
+}

--- a/src/neuroglancer/widget/minimizable_group.ts
+++ b/src/neuroglancer/widget/minimizable_group.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2019 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './minimizable_group.css';
+
+import {RefCounted} from 'neuroglancer/util/disposable';
+import {removeFromParent} from 'neuroglancer/util/dom';
+
+export class MinimizableGroupWidget extends RefCounted {
+  element = document.createElement('div');
+  private label = document.createElement('div');
+  private content = document.createElement('div');
+  constructor(title: string) {
+    super();
+    const {label, content, element} = this;
+
+    label.textContent = title;
+    label.className = 'neuroglancer-minimizable-group-title';
+    label.addEventListener('click', () => {
+      content.classList.toggle('minimized');
+      label.classList.toggle('minimized');
+    });
+
+    content.className = 'neuroglancer-minimizable-group-content';
+    element.className = 'neuroglancer-minimizable-group';
+    element.appendChild(label);
+    element.appendChild(content);
+  }
+
+  disposed() {
+    removeFromParent(this.element);
+    super.disposed();
+  }
+
+  appendFixedChild(el: HTMLElement) {
+    const container = document.createElement('div');
+    container.className = 'neuroglancer-minimizable-group-fixed';
+    container.appendChild(el);
+    this.content.appendChild(container);
+  }
+
+  appendFlexibleChild(el: HTMLElement) {
+    const container = document.createElement('div');
+    container.className = 'neuroglancer-minimizable-group-flexible';
+    container.appendChild(el);
+    this.content.appendChild(container);
+  }
+}

--- a/src/neuroglancer/widget/segment_set_widget.css
+++ b/src/neuroglancer/widget/segment_set_widget.css
@@ -20,15 +20,10 @@
 }
 
 .segment-set-widget {
-  flex: 1;
   overflow-y: auto;
-  height: 0px;
-  min-height: 0px;
-  flex-basis: 0px;
 }
 
 .segment-set-widget .item-container {
-  flex: 1;
   display: flex;
   flex-wrap: wrap;
 }

--- a/src/neuroglancer/widget/tab_view.css
+++ b/src/neuroglancer/widget/tab_view.css
@@ -69,5 +69,6 @@
 }
 
 .neuroglancer-tab-content {
-  flex: 1;
+  flex: 0 1 auto;
+  overflow-y: auto;
 }


### PR DESCRIPTION
Introduces a "minimizable group" container, that allows to
* group widgets into submenus
* hide groups
* allows to mark widgets as rigid/important or scrollable/shrinkable