### PR TITLE
Fix: Correctly set up 2D, 3D and root segments when merging/cutting without graph

### DIFF
--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -339,24 +339,30 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
       }
     }
 
-    rootSegmentChange(rootSegment: Uint64|null, added: boolean) {
-      if (rootSegment === null && !added) {
-        // Clear all segment sets
-        let leafSegmentCount = this.displayState.visibleSegments2D!.size;
-        this.displayState.visibleSegments2D!.clear();
-        this.displayState.visibleSegments3D.clear();
-        this.displayState.segmentEquivalences.clear();
-        StatusMessage.showTemporaryMessage(`Deselected all ${leafSegmentCount} segments.`, 3000);
+    rootSegmentChange(rootSegments: Uint64[]|null, added: boolean) {
+      if (rootSegments === null) {
+        if (added) {
+          return;
+        } else {
+          // Clear all segment sets
+          let leafSegmentCount = this.displayState.visibleSegments2D!.size;
+          this.displayState.visibleSegments2D!.clear();
+          this.displayState.visibleSegments3D.clear();
+          this.displayState.segmentEquivalences.clear();
+          StatusMessage.showTemporaryMessage(`Deselected all ${leafSegmentCount} segments.`, 3000);
+        }
       } else if (added) {
-        this.displayState.visibleSegments3D.add(rootSegment!);
-        this.displayState.visibleSegments2D!.add(rootSegment!);
+        this.displayState.visibleSegments3D.add(rootSegments!);
+        this.displayState.visibleSegments2D!.add(rootSegments!);
       } else if (!added) {
-        let segments = [...this.displayState.segmentEquivalences.setElements(rootSegment!)];
-        let segmentCount = segments.length;  // Approximation
-        this.displayState.visibleSegments2D!.delete(rootSegment!);
-        this.displayState.visibleSegments3D.delete(segments);
-        this.displayState.segmentEquivalences.deleteSet(rootSegment!);
-        StatusMessage.showTemporaryMessage(`Deselected ${segmentCount} segments.`);
+        for (const rootSegment of rootSegments) {
+          const segments = [...this.displayState.segmentEquivalences.setElements(rootSegment)];
+          const segmentCount = segments.length;  // Approximation
+          this.displayState.visibleSegments2D!.delete(rootSegment);
+          this.displayState.visibleSegments3D.delete(segments);
+          this.displayState.segmentEquivalences.deleteSet(rootSegment);
+          StatusMessage.showTemporaryMessage(`Deselected ${segmentCount} segments.`);
+        }
       }
       this.specificationChanged.dispatch();
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "sourceMap": true,
     "moduleResolution": "node",
     "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "es2017", "esnext"],
     "newLine": "LF",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- fixes an issue where a Uint64[][] got accidentally passed to the hashmap, resulting in endless rehashing attempts
- rework `two-point merge`, `merge-selected` and `cut-selected` for `SegmentationUserLayer`.
  - Only group representatives will be shown in the segment selection
  - Merging and splitting correctly updates `visibleSegments2D`, `visibleSegments3D` and `rootSegments`
- Added `"lib": ["dom", "dom.iterable", "es2017", "esnext"]` to use fancy esnext `Array.flatMap`