### PR TITLE
Fix: add omni segment widget when layer is not initially selected

### DIFF
--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -741,6 +741,7 @@ class DisplayOptionsTab extends Tab {
     this.registerDisposer(this.layer.objectLayerStateChanged.add(maybeAddSkeletonShaderUI));
     this.registerDisposer(this.layer.objectLayerStateChanged.add(maybeAddOmniSegmentWidget));
     maybeAddSkeletonShaderUI();
+    maybeAddOmniSegmentWidget();
 
     element.appendChild(group2D.element);
     element.appendChild(group3D.element);


### PR DESCRIPTION
When the initially selected layer is not the segmentation layer with the omni widget, the widget never loads. This commit fixes that.