### PR TITLE
Limit get_leaves requests to the ChunkedGraph based on zoom level

### DIFF
--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -267,6 +267,8 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
         if (rootSegments.has(segment)) {
           rootSegments.delete(segment);
         } else if (this.chunkedGraphLayer) {
+          StatusMessage.showTemporaryMessage(
+              'The selected segment will not be displayed in 2D at this current zoom level. ');
           const currentSegmentSelection: SegmentSelection = {
             segmentId: segmentSelectionState.selectedSegment.clone(),
             rootId: segmentSelectionState.selectedSegment.clone(),

--- a/src/neuroglancer/sliceview/base.ts
+++ b/src/neuroglancer/sliceview/base.ts
@@ -358,9 +358,6 @@ export class SliceViewBase<Source extends SliceViewChunkSource,
       const smallestVoxelSize = transformedSources[0][0].voxelSize;
 
       if (renderLayer.renderRatioLimit !== undefined) {
-        // tempVec3 represents diagonal across one highest-resolution voxel in slice
-        vec3.add(tempVec3, this.viewportAxes[0], this.viewportAxes[1]);
-        vec3.mul(tempVec3, tempVec3, smallestVoxelSize);
         // If the pixel nm size in the slice is bigger than this diagonal by
         // a certain ratio (right now semi-arbitarily set as a constant in chunked_graph/base.ts)
         // we do not request the ChunkedGraph for root -> supervoxel mappings, and

--- a/src/neuroglancer/sliceview/base.ts
+++ b/src/neuroglancer/sliceview/base.ts
@@ -139,6 +139,7 @@ export interface RenderLayer<Source extends SliceViewChunkSource> {
   transformedSources: TransformedSource<Source>[][]|undefined;
   transformedSourcesGeneration: number;
   renderScaleTarget: WatchableValueInterface<number>;
+  screenPixelSizeToSourceVoxelSizeRatioRenderLimit?: number;
 }
 
 export function getTransformedSources<Source extends SliceViewChunkSource>(
@@ -353,6 +354,13 @@ export class SliceViewBase<Source extends SliceViewChunkSource,
       // At the smallest scale, all alternative sources must have the same voxel size, which is
       // considered to be the base voxel size.
       const smallestVoxelSize = transformedSources[0][0].voxelSize;
+
+      const ratioLimit = renderLayer.screenPixelSizeToSourceVoxelSizeRatioRenderLimit;
+      if (ratioLimit !== undefined) {
+        if (ratioLimit < (pixelSize / vec3.length(smallestVoxelSize))) {
+          continue;
+        }
+      }
 
       const renderScaleTarget = renderLayer.renderScaleTarget.value;
 

--- a/src/neuroglancer/sliceview/chunked_graph/backend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/backend.ts
@@ -191,6 +191,7 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
   rootSegments: Uint64Set;
   visibleSegments3D: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;
+  screenPixelSizeToSourceVoxelSizeRatioRenderLimit: number;
 
 
   constructor(rpc: RPC, options: any) {
@@ -200,6 +201,7 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
     this.visibleSegments3D = <Uint64Set>rpc.get(options['visibleSegments3D']);
     this.segmentEquivalences = <SharedDisjointUint64Sets>rpc.get(options['segmentEquivalences']);
     this.renderScaleTarget = rpc.get(options['renderScaleTarget']);
+    this.screenPixelSizeToSourceVoxelSizeRatioRenderLimit = options['screenPixelSizeToSourceVoxelSizeRatioRenderLimit'];
 
     this.sources = new Array<ChunkedGraphChunkSource[]>();
     for (const alternativeIds of options['sources']) {

--- a/src/neuroglancer/sliceview/chunked_graph/backend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/backend.ts
@@ -21,7 +21,7 @@ import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
 import {SliceViewChunk, SliceViewChunkSource} from 'neuroglancer/sliceview/backend';
 import {RenderLayer as RenderLayerInterface, TransformedSource} from 'neuroglancer/sliceview/base';
-import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification} from 'neuroglancer/sliceview/chunked_graph/base';
+import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {mat4, vec3, vec3Key} from 'neuroglancer/util/geom';
 import {NullarySignal} from 'neuroglancer/util/signal';
@@ -191,8 +191,6 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
   rootSegments: Uint64Set;
   visibleSegments3D: Uint64Set;
   segmentEquivalences: SharedDisjointUint64Sets;
-  screenPixelSizeToSourceVoxelSizeRatioRenderLimit: number;
-
 
   constructor(rpc: RPC, options: any) {
     super(rpc, options);
@@ -201,7 +199,6 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
     this.visibleSegments3D = <Uint64Set>rpc.get(options['visibleSegments3D']);
     this.segmentEquivalences = <SharedDisjointUint64Sets>rpc.get(options['segmentEquivalences']);
     this.renderScaleTarget = rpc.get(options['renderScaleTarget']);
-    this.screenPixelSizeToSourceVoxelSizeRatioRenderLimit = options['screenPixelSizeToSourceVoxelSizeRatioRenderLimit'];
 
     this.sources = new Array<ChunkedGraphChunkSource[]>();
     for (const alternativeIds of options['sources']) {
@@ -227,6 +224,12 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
 
   get url() {
     return this.graphurl;
+  }
+
+  // Used for the sliceview to set a limit on when to
+  // make get_leaves to the ChunkedGraph
+  get renderRatioLimit() {
+    return RENDER_RATIO_LIMIT;
   }
 
   private debouncedupdateDisplayState = debounce(() => {

--- a/src/neuroglancer/sliceview/chunked_graph/base.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/base.ts
@@ -19,7 +19,7 @@ import {getCombinedTransform} from 'neuroglancer/sliceview/base';
 import {kZeroVec, vec3} from 'neuroglancer/util/geom';
 
 export const CHUNKED_GRAPH_LAYER_RPC_ID = 'ChunkedGraphLayer';
-
+export const RENDER_RATIO_LIMIT = 5.0;
 
 export interface ChunkedGraphSourceOptions extends SliceViewSourceOptions {
   rootUri: string;

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -28,6 +28,7 @@ import {RPC} from 'neuroglancer/worker_rpc';
 
 export const GRAPH_SERVER_NOT_SPECIFIED = Symbol('Graph Server Not Specified.');
 
+const SCREEN_PIXEL_SIZE_TO_SOURCE_VOXEL_SIZE_RATIO_RENDER_LIMIT = 1.0;
 export interface SegmentSelection {
   segmentId: Uint64;
   rootId: Uint64;
@@ -55,6 +56,7 @@ export class ChunkedGraphChunkSource extends SliceViewChunkSource implements
 
 export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
   private graphurl: string;
+  private _screenPixelSizeToSourceVoxelSizeRatioRenderLimit: number;
 
   constructor(
       chunkManager: ChunkManager, url: string, public sources: ChunkedGraphChunkSource[][],
@@ -65,16 +67,22 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
         'url': url,
         'rootSegments': displayState.rootSegments.rpcId,
         'visibleSegments3D': displayState.visibleSegments3D.rpcId,
-        'segmentEquivalences': displayState.segmentEquivalences.rpcId
+        'segmentEquivalences': displayState.segmentEquivalences.rpcId,
+        'screenPixelSizeToSourceVoxelSizeRatioRenderLimit': SCREEN_PIXEL_SIZE_TO_SOURCE_VOXEL_SIZE_RATIO_RENDER_LIMIT
       },
       rpcType: CHUNKED_GRAPH_LAYER_RPC_ID,
       transform: displayState.transform,
     });
+    this._screenPixelSizeToSourceVoxelSizeRatioRenderLimit = SCREEN_PIXEL_SIZE_TO_SOURCE_VOXEL_SIZE_RATIO_RENDER_LIMIT;
     this.graphurl = url;
   }
 
   get url() {
     return this.graphurl;
+  }
+
+  get screenPixelSizeToSourceVoxelSizeRatioRenderLimit() {
+    return this._screenPixelSizeToSourceVoxelSizeRatioRenderLimit;
   }
 
   async getRoot(selection: SegmentSelection): Promise<Uint64> {

--- a/src/neuroglancer/sliceview/renderlayer.ts
+++ b/src/neuroglancer/sliceview/renderlayer.ts
@@ -30,7 +30,7 @@ import {SharedObject} from 'neuroglancer/worker_rpc';
 export interface RenderLayerOptions {
   transform?: CoordinateTransform;
   rpcType?: string;
-  rpcTransfer?: { [index:string]: number|string|null };
+  rpcTransfer?: { [index:string]: number|string|boolean|null };
   renderScaleTarget?: WatchableValueInterface<number>;
   renderScaleHistogram?: RenderScaleHistogram;
 }
@@ -38,7 +38,7 @@ export interface RenderLayerOptions {
 export abstract class RenderLayer extends GenericRenderLayer {
   rpcId: RpcId|null = null;
   rpcType: string = SLICEVIEW_RENDERLAYER_RPC_ID;
-  rpcTransfer: { [index:string]: number|string|null } = {};
+  rpcTransfer: { [index:string]: number|string|boolean|null } = {};
   shaderError: WatchableShaderError;
   transform: CoordinateTransform;
   transformedSources: TransformedSource<SliceViewChunkSource>[][];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedParameters": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "preserveConstEnums": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedParameters": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "preserveConstEnums": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Added a constant that represents max ratio allowed between screen pixel size (nm) and dataset voxel size (nm) for neuroglancer to send leaves requests to the ChunkedGraph server. If this limit is exceeded by zooming out, the user sees a warning that new 2D segmentation will not be loaded for ChunkedGraph layers at the current zoom level.