### PR TITLE
Fix: after restoreState, CG Segmentation user layer's source had old version of rootSegments

### DIFF
--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -21,7 +21,7 @@ import {GraphOperationLayerState} from 'neuroglancer/graph/graph_operation_layer
 import {registerLayerType, registerVolumeLayerType} from 'neuroglancer/layer_specification';
 import {SegmentationDisplayState} from 'neuroglancer/segmentation_display_state/frontend';
 import {SegmentationUserLayer, SegmentationUserLayerDisplayState} from 'neuroglancer/segmentation_user_layer';
-import {ChunkedGraphLayer, SegmentSelection} from 'neuroglancer/sliceview/chunked_graph/frontend';
+import {ChunkedGraphChunkSource, ChunkedGraphLayer, SegmentSelection} from 'neuroglancer/sliceview/chunked_graph/frontend';
 import {VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {SupervoxelRenderLayer} from 'neuroglancer/sliceview/volume/supervoxel_renderlayer';
 import {StatusMessage} from 'neuroglancer/status';
@@ -158,6 +158,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
                   {rootUri: this.chunkedGraphUrl}, displayState.rootSegments);
 
               if (chunkedGraphSources) {
+                this.updateChunkSourceRootSegments(chunkedGraphSources);
                 this.chunkedGraphLayer = new ChunkedGraphLayer(
                     this.manager.chunkManager, this.chunkedGraphUrl, chunkedGraphSources,
                     {...displayState, transform: displayState.objectToDataTransform});
@@ -449,6 +450,16 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
         }
       }
       this.specificationChanged.dispatch();
+    }
+
+    private updateChunkSourceRootSegments(chunkedGraphChunkSources: ChunkedGraphChunkSource[][]) {
+      chunkedGraphChunkSources.forEach(chunkedGraphChunkSourceList => {
+        chunkedGraphChunkSourceList.forEach(chunkedGraphChunkSource => {
+          if (chunkedGraphChunkSource.rootSegments !== this.displayState.rootSegments) {
+            chunkedGraphChunkSource.updateRootSegments(this.manager.rpc, this.displayState.rootSegments);
+          }
+        });
+      });
     }
   }
   return C;

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -456,7 +456,8 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
       chunkedGraphChunkSources.forEach(chunkedGraphChunkSourceList => {
         chunkedGraphChunkSourceList.forEach(chunkedGraphChunkSource => {
           if (chunkedGraphChunkSource.rootSegments !== this.displayState.rootSegments) {
-            chunkedGraphChunkSource.updateRootSegments(this.manager.rpc, this.displayState.rootSegments);
+            chunkedGraphChunkSource.updateRootSegments(
+                this.manager.rpc, this.displayState.rootSegments);
           }
         });
       });

--- a/src/neuroglancer/sliceview/chunked_graph/backend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/backend.ts
@@ -21,12 +21,12 @@ import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
 import {SliceViewChunk, SliceViewChunkSource} from 'neuroglancer/sliceview/backend';
 import {RenderLayer as RenderLayerInterface, TransformedSource} from 'neuroglancer/sliceview/base';
-import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID} from 'neuroglancer/sliceview/chunked_graph/base';
+import {CHUNKED_GRAPH_LAYER_RPC_ID, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {mat4, vec3, vec3Key} from 'neuroglancer/util/geom';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
-import {registerSharedObject, RPC, SharedObjectCounterpart, registerRPC} from 'neuroglancer/worker_rpc';
+import {registerRPC, registerSharedObject, RPC, SharedObjectCounterpart} from 'neuroglancer/worker_rpc';
 import {WatchableValueInterface} from 'src/neuroglancer/trackable_value';
 
 const tempChunkDataSize = vec3.create();

--- a/src/neuroglancer/sliceview/chunked_graph/backend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/backend.ts
@@ -21,12 +21,12 @@ import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
 import {SliceViewChunk, SliceViewChunkSource} from 'neuroglancer/sliceview/backend';
 import {RenderLayer as RenderLayerInterface, TransformedSource} from 'neuroglancer/sliceview/base';
-import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
+import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID} from 'neuroglancer/sliceview/chunked_graph/base';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {mat4, vec3, vec3Key} from 'neuroglancer/util/geom';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
-import {registerSharedObject, RPC, SharedObjectCounterpart} from 'neuroglancer/worker_rpc';
+import {registerSharedObject, RPC, SharedObjectCounterpart, registerRPC} from 'neuroglancer/worker_rpc';
 import {WatchableValueInterface} from 'src/neuroglancer/trackable_value';
 
 const tempChunkDataSize = vec3.create();
@@ -291,3 +291,8 @@ export class ChunkedGraphLayer extends Base implements RenderLayerInterface<Slic
     }
   }
 }
+
+registerRPC(CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, function(x: any) {
+  const chunkedGraphChunkSource = <ChunkedGraphChunkSource>this.get(x.id);
+  chunkedGraphChunkSource.rootSegments = this.get(x.rootSegments);
+});

--- a/src/neuroglancer/sliceview/chunked_graph/base.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/base.ts
@@ -19,6 +19,8 @@ import {getCombinedTransform} from 'neuroglancer/sliceview/base';
 import {kZeroVec, vec3} from 'neuroglancer/util/geom';
 
 export const CHUNKED_GRAPH_LAYER_RPC_ID = 'ChunkedGraphLayer';
+export const CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID =
+    'ChunkedGraphSourceUpdateRootSegments';
 export const RENDER_RATIO_LIMIT = 5.0;
 
 export interface ChunkedGraphSourceOptions extends SliceViewSourceOptions {

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -17,7 +17,7 @@
 import {authFetch} from 'neuroglancer/authentication/frontend.ts';
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
 import {VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';
-import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
+import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID} from 'neuroglancer/sliceview/chunked_graph/base';
 import {SliceViewChunkSource} from 'neuroglancer/sliceview/frontend';
 import {RenderLayer as GenericSliceViewRenderLayer, RenderLayerOptions} from 'neuroglancer/sliceview/renderlayer';
 import {StatusMessage} from 'neuroglancer/status';
@@ -51,6 +51,14 @@ export class ChunkedGraphChunkSource extends SliceViewChunkSource implements
   initializeCounterpart(rpc: RPC, options: any) {
     options['rootSegments'] = this.rootSegments.rpcId;
     super.initializeCounterpart(rpc, options);
+  }
+
+  updateRootSegments(rpc: RPC, rootSegments: Uint64Set) {
+    this.rootSegments = rootSegments;
+    rpc.invoke(CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, {
+      'id': this.rpcId,
+      'rootSegments': this.rootSegments.rpcId
+    });
   }
 }
 

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -17,7 +17,7 @@
 import {authFetch} from 'neuroglancer/authentication/frontend.ts';
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
 import {VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';
-import {CHUNKED_GRAPH_LAYER_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID} from 'neuroglancer/sliceview/chunked_graph/base';
+import {CHUNKED_GRAPH_LAYER_RPC_ID, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
 import {SliceViewChunkSource} from 'neuroglancer/sliceview/frontend';
 import {RenderLayer as GenericSliceViewRenderLayer, RenderLayerOptions} from 'neuroglancer/sliceview/renderlayer';
 import {StatusMessage} from 'neuroglancer/status';
@@ -55,10 +55,9 @@ export class ChunkedGraphChunkSource extends SliceViewChunkSource implements
 
   updateRootSegments(rpc: RPC, rootSegments: Uint64Set) {
     this.rootSegments = rootSegments;
-    rpc.invoke(CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, {
-      'id': this.rpcId,
-      'rootSegments': this.rootSegments.rpcId
-    });
+    rpc.invoke(
+        CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID,
+        {'id': this.rpcId, 'rootSegments': this.rootSegments.rpcId});
   }
 }
 


### PR DESCRIPTION
SegmentationUserLayerWithGraph's ChunkedGraphSource never updated its version of rootSegments after restoreState, causing incorrect leaves requests to the ChunkedGraph on the backend