### PR TITLE
feat: Split preview for multicut

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,11 @@
-### September 12 2019
-# Select segment colors
-* In the segment set widget, a new button allows you to control the color of each segment you select.
-* The button is right next to the segment's visibility checkbox, it is a rectangle whose color is that of the segment.
-* The selected colors are saved in the URL.
+### September 10 2019
+# Split Preview
+* Ever wanted to see the results of your actions before you perform them?
+* You're in luck! The new split preview button allows you to see forward in time!
+* The split preview button is available for ChunkedGraph segmentation layers in the graph tab.
+* In the Multicut group, it is the rightmost button that looks like a crystal ball.
+* When performing a split, the split preview will show you what changes your split will make in 2D, without actually changing the underlying segmentation.
+* Hit the crystall ball to toggle between split preview mode and regular multicut mode.
+
+# Multicut surrounding segment opacity
+* You can now control the opacity of the surrounding segments while performing a multicut, if you wish to view more context. Use the range slider in the "Multicut Opacity" group to do so.

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -148,7 +148,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     });
 
     const response = await this.withErrorMessage(promise, {
-      initialMessage: `Splitting ${second.length} sinks from ${first.length} sources`,
+      initialMessage: `Splitting ${first.length} sources from ${second.length} sinks`,
       errorPrefix: 'Split failed: '
     });
     const jsonResp = await response.json();
@@ -176,7 +176,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
 
     const response = await this.withErrorMessage(promise, {
       initialMessage:
-          `Calculating split preview: ${second.length} sinks, and ${first.length} sources`,
+          `Calculating split preview: ${first.length} sources, and ${second.length} sinks`,
       errorPrefix: 'Split preview failed: '
     });
     const jsonResp = await response.json();

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -180,7 +180,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       errorPrefix: 'Split preview failed: '
     });
     const jsonResp = await response.json();
-    const jsonCCKey = 'supervoxel_connected_components_string';
+    const jsonCCKey = 'supervoxel_connected_components';
     const supervoxelConnectedComponents: Uint64Set[] = new Array(jsonResp[jsonCCKey].length);
     for (let i = 0; i < supervoxelConnectedComponents.length; i++) {
       const connectedComponent = new Array(jsonResp[jsonCCKey][i].length);

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -148,7 +148,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     });
 
     const response = await this.withErrorMessage(promise, {
-      initialMessage: `Splitting ${first.length} sinks from ${second.length} sources`,
+      initialMessage: `Splitting ${second.length} sinks from ${first.length} sources`,
       errorPrefix: 'Split failed: '
     });
     const jsonResp = await response.json();
@@ -157,6 +157,42 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       final[i] = Uint64.parseString(jsonResp['new_root_ids'][i]);
     }
     return final;
+  }
+
+  async splitPreview(first: SegmentSelection[], second: SegmentSelection[]):
+      Promise<{supervoxelConnectedComponents: Uint64Set[], isSplitIllegal: boolean}> {
+    const {url} = this;
+    if (url === '') {
+      return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
+    }
+
+    const promise = authFetch(`${url}/graph/split_preview`, {
+      method: 'POST',
+      body: JSON.stringify({
+        'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),
+        'sinks': second.map(x => [String(x.segmentId), ...x.position.values()])
+      })
+    });
+
+    const response = await this.withErrorMessage(promise, {
+      initialMessage:
+          `Calculating split preview: ${second.length} sinks, and ${first.length} sources`,
+      errorPrefix: 'Split preview failed: '
+    });
+    const jsonResp = await response.json();
+    const jsonCCKey = 'supervoxel_connected_components_string';
+    const supervoxelConnectedComponents: Uint64Set[] = new Array(jsonResp[jsonCCKey].length);
+    for (let i = 0; i < supervoxelConnectedComponents.length; i++) {
+      const connectedComponent = new Array(jsonResp[jsonCCKey][i].length);
+      for (let j = 0; j < jsonResp[jsonCCKey][i].length; j++) {
+        connectedComponent[j] = Uint64.parseString(jsonResp[jsonCCKey][i][j], 10);
+      }
+      const connectedComponentSet = new Uint64Set();
+      connectedComponentSet.add(connectedComponent);
+      supervoxelConnectedComponents[i] = connectedComponentSet;
+    }
+    const jsonIllegalSplitKey = 'illegal_split';
+    return {supervoxelConnectedComponents, isSplitIllegal: jsonResp[jsonIllegalSplitKey]};
   }
 
   draw() {}

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -166,7 +166,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/graph/split_preview`, {
+    const promise = authFetch(`${url}/graph/split_preview?int64_as_str=1`, {
       method: 'POST',
       body: JSON.stringify({
         'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),

--- a/src/neuroglancer/sliceview/volume/supervoxel_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/supervoxel_renderlayer.ts
@@ -80,7 +80,7 @@ export class SupervoxelRenderLayer extends RenderLayer {
     if (this.displayState.hideSegmentZero.value) {
       fragmentMain += `
     if ((value.value[0] == 0u && value.value[1] == 0u) || uPerformingMulticut == 0u) {
-      emit(vec4(vec4(0, 0, 0, 0)));
+      emit(vec4(0, 0, 0, 0));
       return;
     }
   `;

--- a/src/neuroglancer/status.ts
+++ b/src/neuroglancer/status.ts
@@ -103,7 +103,7 @@ export class StatusMessage {
   }
 
   static messageWithAction(
-      message: string, actionMessage: string, action: () => void, closeAfter: number = 10000) {
+      message: string, actionMessage: string, action: () => void, closeAfter?: number) {
     const msg = this.showMessage(message);
     const actionButton = document.createElement('button');
     actionButton.textContent = actionMessage;
@@ -112,7 +112,9 @@ export class StatusMessage {
       msg.dispose();
     });
     msg.element.appendChild(actionButton);
-    setTimeout(() => msg.dispose(), closeAfter);
+    if (closeAfter !== undefined) {
+      setTimeout(() => msg.dispose(), closeAfter);
+    }
     return msg;
   }
 

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -334,6 +334,7 @@ export class GraphOperationLayerView extends Tab {
       toolbox.appendChild(toggleGroupButton);
     }
 
+    const splitPreviewWrapper = new SplitPreview(this.wrapper, this.annotationLayer);
     const confirmButton = document.createElement('button');
     {
       confirmButton.textContent = '✔️';
@@ -341,6 +342,7 @@ export class GraphOperationLayerView extends Tab {
       confirmButton.addEventListener('click', () => {
         const {sources, sinks} = this.annotationLayer.getSourcesAndSinks();
         this.wrapper.chunkedGraphLayer!.splitSegments(sources, sinks).then((splitRoots) => {
+          splitPreviewWrapper.disablePreview();
           if (splitRoots.length === 0) {
             StatusMessage.showTemporaryMessage(`No split found.`, 3000);
           } else {
@@ -381,10 +383,7 @@ export class GraphOperationLayerView extends Tab {
       toolbox.appendChild(cancelButton);
     }
 
-    {
-      const splitPreviewWrapper = new SplitPreview(this.wrapper, this.annotationLayer);
-      toolbox.appendChild(splitPreviewWrapper.button);
-    }
+    { toolbox.appendChild(splitPreviewWrapper.button); }
 
     this.multicutGroup.appendFixedChild(toolbox);
     this.multicutGroup.appendFlexibleChild(this.annotationListContainer);
@@ -663,6 +662,8 @@ class SplitPreview extends RefCounted {
                   this.enablePreview();
                 })
                 .catch(() => {
+                  StatusMessage.messageWithAction(
+                      'Split preview is not supported for this dataset. ', 'Ok', () => {});
                   this.revertPreviewButton();
                   this.previewPending = false;
                 });
@@ -719,7 +720,7 @@ class SplitPreview extends RefCounted {
         });
       }
 
-  private disablePreview =
+  public disablePreview =
       () => {
         this.inPreviewMode = false;
         this.revertPreviewButton();

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -668,8 +668,6 @@ class SplitPreview extends RefCounted {
                     this.enablePreview();
                   })
                   .catch(() => {
-                    StatusMessage.messageWithAction(
-                        'Split preview is not supported for this dataset. ', 'Ok', () => {});
                     this.revertPreviewButton();
                     this.previewPending = false;
                   });


### PR DESCRIPTION
A new "crystal ball" button in the multicut group performs a split preview. It hits the split_preview endpoint in the ChunkedGraph, which calculates the mincut given the sources and sinks but does not actually update the graph. The CG returns the connected components of supervoxels in the region around the cut, assuming the split were to take place. This is displayed to the user as groups of red and blue supervoxels. 

Note: for this PR to work the associated ChunkedGraph PR, https://github.com/seung-lab/PyChunkedGraph/pull/162, has to be online.