### PR TITLE
feat(datasource/precomputed): Layer redirection support

### DIFF
--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -16,7 +16,7 @@
 
 import {AnnotationSource, makeDataBoundsBoundingBox} from 'neuroglancer/annotation';
 import {ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/frontend';
-import {DataSource} from 'neuroglancer/datasource';
+import {DataSource, RedirectError} from 'neuroglancer/datasource';
 import {DataEncoding, MeshSourceParameters, MultiscaleMeshMetadata, MultiscaleMeshSourceParameters, ShardingHashFunction, ShardingParameters, SkeletonMetadata, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/precomputed/base';
 import {VertexPositionFormat} from 'neuroglancer/mesh/base';
 import {MeshSource, MultiscaleMeshSource} from 'neuroglancer/mesh/frontend';
@@ -135,6 +135,11 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
 
   constructor(public chunkManager: ChunkManager, public url: string, obj: any) {
     verifyObject(obj);
+    const redirect = verifyObjectProperty(obj, 'redirect', verifyOptionalString);
+    if (redirect !== undefined) {
+      throw new RedirectError(redirect);
+    }
+
     const t = verifyObjectProperty(obj, '@type', verifyOptionalString);
     if (t !== undefined && t !== 'neuroglancer_multiscale_volume') {
       throw new Error(`Invalid type: ${JSON.stringify(t)}`);


### PR DESCRIPTION
This PR adds support for a new key `redirect` to the precomputed info file. If specified, it will work as an automatic layer source redirection. This is useful in order to forward users who use old, bookmarked links to newer versions / formats of the specified layer.

Throws an error if more than 10 redirects occur, or a cycle is detected.
Works for loading existing links, as well as when trying to add layers via the layer dialog.