### PR TITLE
Feat (graphene): Path Finding Widget

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,4 +1,8 @@
-### October 31 2019
-## Keep focus when moving mouse off of textboxes
-* For the navigation coordinates at the top, the shader code, and the transformation matrix, focus will no longer be lost when moving the mouse off the text and onto another area.
-* Elements will still be unfocused when clicking on another panel.
+### October 1 2019
+# Find a path between two points in a segment
+* A new feature helps users find locations of mergers.
+* For graphene segmentation layers, a new widget has been added to the "Graph" tab. It is labeled "Find Path."
+* One can select the point selection button, select a source and target point and hit the check mark to request a path between the points.
+* The ChunkedGraph server will then compute a path and it will be shown in Neuroglancer.
+* One can imagine a workflow to break up complex mergers of labeling two points clearly in different segments, finding a path
+between them, splitting them, and repeating the process.

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,4 +1,4 @@
-### October 1 2019
+### November 25 2019
 # Find a path between two points in a segment
 * A new feature helps users find locations of mergers.
 * For graphene segmentation layers, a new widget has been added to the "Graph" tab. It is labeled "Find Path."

--- a/src/neuroglancer/annotation/index.ts
+++ b/src/neuroglancer/annotation/index.ts
@@ -535,7 +535,7 @@ export class AnnotationSource extends RefCounted implements AnnotationSourceSign
     this.changed.dispatch();
   }
 
-  restoreState(annotationObj: any, annotationTagObj: any) {
+  restoreState(annotationObj: any, annotationTagObj: any, allowMissingId = false) {
     const {annotationMap, tags: annotationTags} = this;
     annotationTags.clear();
     annotationMap.clear();
@@ -556,7 +556,7 @@ export class AnnotationSource extends RefCounted implements AnnotationSourceSign
     }
     if (annotationObj !== undefined) {
       parseArray(annotationObj, x => {
-        const annotation = restoreAnnotation(x);
+        const annotation = restoreAnnotation(x, allowMissingId);
         this.insertAnnotationNode(annotation);
       });
     }

--- a/src/neuroglancer/graph/path_finder_state.ts
+++ b/src/neuroglancer/graph/path_finder_state.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {vec3} from 'gl-matrix';
+import {vec3} from 'neuroglancer/util/geom';
 import {annotationToJson, AnnotationType, Line, LocalAnnotationSource, Point, restoreAnnotation} from 'neuroglancer/annotation';
 import {AnnotationLayerState} from 'neuroglancer/annotation/frontend';
 import {CoordinateTransform} from 'neuroglancer/coordinate_transform';

--- a/src/neuroglancer/graph/path_finder_state.ts
+++ b/src/neuroglancer/graph/path_finder_state.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2019 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {vec3} from 'gl-matrix';
+import {annotationToJson, AnnotationType, Line, LocalAnnotationSource, Point, restoreAnnotation} from 'neuroglancer/annotation';
+import {AnnotationLayerState} from 'neuroglancer/annotation/frontend';
+import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
+import {MouseSelectionState} from 'neuroglancer/layer';
+import {SegmentationUserLayerWithGraph} from 'neuroglancer/segmentation_user_layer_with_graph';
+import {StatusMessage} from 'neuroglancer/status';
+import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
+import {WatchableRefCounted} from 'neuroglancer/trackable_value';
+import {Tool} from 'neuroglancer/ui/tool';
+import {serializeColor, TrackableRGB} from 'neuroglancer/util/color';
+import {RefCounted} from 'neuroglancer/util/disposable';
+import {NullarySignal} from 'neuroglancer/util/signal';
+import {Uint64} from 'neuroglancer/util/uint64';
+
+const ANNOTATION_COLOR_JSON_KEY = 'color';
+const PATH_OBJECT_JSON_KEY = 'pathObject';
+
+const PATH_SOURCE_JSON_KEY = 'source';
+const PATH_TARGET_JSON_KEY = 'target';
+const HAS_PATH_JSON_KEY = 'hasPath';
+const ANNOTATION_PATH_JSON_KEY = 'annotationPath';
+
+export class PathFinderState extends RefCounted {
+  pathBetweenSupervoxels: PathBetweenSupervoxels;
+  annotationLayerState = this.registerDisposer(new WatchableRefCounted<AnnotationLayerState>());
+  pathAnnotationColor = new TrackableRGB(vec3.fromValues(1.0, 1.0, 0.0));
+  changed = new NullarySignal();
+
+  constructor(transform: CoordinateTransform) {
+    super();
+    const annotationSource = this.registerDisposer(new LocalAnnotationSource());
+    this.pathBetweenSupervoxels =
+        this.registerDisposer(new PathBetweenSupervoxels(annotationSource));
+    this.annotationLayerState.value = new AnnotationLayerState({
+      transform,
+      source: annotationSource.addRef(),
+      fillOpacity: trackableAlphaValue(1.0),
+      color: this.pathAnnotationColor,
+    });
+    this.registerDisposer(this.pathBetweenSupervoxels.changed.add(this.changed.dispatch));
+    this.registerDisposer(this.pathAnnotationColor.changed.add(this.changed.dispatch));
+  }
+
+  restoreState(x: any) {
+    this.pathAnnotationColor.restoreState(x[ANNOTATION_COLOR_JSON_KEY]);
+    this.pathBetweenSupervoxels.restoreState(x[PATH_OBJECT_JSON_KEY]);
+  }
+
+  toJSON() {
+    return {
+      [ANNOTATION_COLOR_JSON_KEY]: serializeColor(this.pathAnnotationColor.value),
+      [PATH_OBJECT_JSON_KEY]: this.pathBetweenSupervoxels.toJSON()
+    };
+  }
+}
+
+class PathBetweenSupervoxels extends RefCounted {
+  private _source: Point|undefined;
+  private _target: Point|undefined;
+  private _hasPath = false;
+  changed = new NullarySignal();
+
+  constructor(private annotationSource: LocalAnnotationSource) {
+    super();
+  }
+
+  ready() {
+    return this._source !== undefined && this._target !== undefined;
+  }
+
+  get source() {
+    return this._source;
+  }
+
+  get target() {
+    return this._target;
+  }
+
+  get hasPath() {
+    return this._hasPath;
+  }
+
+  addSourceOrTarget(annotation: Point) {
+    if (!this.ready()) {
+      if ((!this.source) && (!this.target)) {
+        // Neither source nor target exist yet
+        this._source = annotation;
+        this.annotationSource.add(this.source!);
+        this.changed.dispatch();
+      } else if (!this.target) {
+        // Source already exists, target doesn't
+        if (Uint64.equal(this._source!.segments![1], annotation.segments![1])) {
+          this._target = annotation;
+          this.annotationSource.add(this.target!);
+          this.changed.dispatch();
+        } else {
+          StatusMessage.showTemporaryMessage('Source and target must belong to the same object');
+        }
+      } else {
+        // Target already exists, source doesn't
+        if (Uint64.equal(this._target!.segments![1], annotation.segments![1])) {
+          this._source = annotation;
+          // Make sure source and target are in the right order
+          this.annotationSource.clear();
+          this.annotationSource.add(this.source!);
+          this.annotationSource.add(this.target!);
+          this.changed.dispatch();
+        } else {
+          StatusMessage.showTemporaryMessage('Source and target must belong to the same object');
+        }
+      }
+    }
+  }
+
+  setPath(path: Line[]) {
+    if (this.ready()) {
+      this.annotationSource.clear();
+      const firstLine: Line =
+          {pointA: this.source!.point, pointB: path[0].pointA, id: '', type: AnnotationType.LINE};
+      this.annotationSource.add(firstLine);
+      for (const line of path) {
+        this.annotationSource.add(line);
+      }
+      const lastLine: Line = {
+        pointA: path[path.length - 1].pointB,
+        pointB: this.target!.point,
+        id: '',
+        type: AnnotationType.LINE
+      };
+      this.annotationSource.add(lastLine);
+      this._hasPath = true;
+      this.changed.dispatch();
+    }
+  }
+
+  clear() {
+    this.annotationSource.clear();
+    this._source = undefined;
+    this._target = undefined;
+    this._hasPath = false;
+    this.changed.dispatch();
+  }
+
+  restoreState(specification: any) {
+    if (specification[ANNOTATION_PATH_JSON_KEY] !== undefined) {
+      this.annotationSource.restoreState(
+          specification[ANNOTATION_PATH_JSON_KEY].annotations, undefined);
+    }
+    if (specification[PATH_SOURCE_JSON_KEY] !== undefined) {
+      this._source = <Point>restoreAnnotation(specification[PATH_SOURCE_JSON_KEY]);
+    }
+    if (specification[PATH_TARGET_JSON_KEY] !== undefined) {
+      this._target = <Point>restoreAnnotation(specification[PATH_TARGET_JSON_KEY]);
+    }
+    if (specification[HAS_PATH_JSON_KEY] !== undefined) {
+      this._hasPath = specification[HAS_PATH_JSON_KEY];
+    }
+    this.changed.dispatch();
+  }
+
+  toJSON() {
+    const x: any = {
+      [ANNOTATION_PATH_JSON_KEY]: this.annotationSource.toJSON(),
+      [HAS_PATH_JSON_KEY]: this._hasPath
+    };
+    if (this._source) {
+      x[PATH_SOURCE_JSON_KEY] = annotationToJson(this._source);
+    }
+    if (this._target) {
+      x[PATH_TARGET_JSON_KEY] = annotationToJson(this._target);
+    }
+    return x;
+  }
+}
+
+export class PathFindingMarkerTool extends Tool {
+  constructor(private layer: SegmentationUserLayerWithGraph) {
+    super();
+  }
+
+  private get pathBetweenSupervoxels() {
+    return this.layer.pathFinderState.pathBetweenSupervoxels;
+  }
+
+  trigger(mouseState: MouseSelectionState) {
+    if (mouseState.active) {
+      const {segmentSelectionState} = this.layer.displayState;
+      if (segmentSelectionState.hasSelectedSegment) {
+        if (this.pathBetweenSupervoxels.ready()) {
+          StatusMessage.showTemporaryMessage(
+              'A source and target have already been selected.', 7000);
+        } else if (!this.layer.displayState.rootSegments.has(
+                       segmentSelectionState.selectedSegment)) {
+          StatusMessage.showTemporaryMessage(
+              'The selected supervoxel is of an unselected segment', 7000);
+        } else {
+          const annotation: Point = {
+            id: '',
+            segments: [
+              segmentSelectionState.rawSelectedSegment.clone(),
+              segmentSelectionState.selectedSegment.clone()
+            ],
+            point: vec3.transformMat4(
+                vec3.create(), this.layer.manager.layerSelectedValues.mouseState.position,
+                this.layer.transform.inverse),
+            type: AnnotationType.POINT,
+          };
+          this.pathBetweenSupervoxels.addSourceOrTarget(annotation);
+        }
+      }
+    }
+  }
+
+  get description() {
+    return `select source & target supervoxel to find a path between`;
+  }
+
+  toJSON() {
+    // Don't register the tool, it's not that important
+    return;
+  }
+}

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -24,15 +24,28 @@ import {StatusMessage} from 'neuroglancer/status';
 import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {vec3} from 'neuroglancer/util/geom';
+import {verify3dVec, verifyObjectProperty} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {RPC} from 'neuroglancer/worker_rpc';
 
 export const GRAPH_SERVER_NOT_SPECIFIED = Symbol('Graph Server Not Specified.');
 
+const SEGMENT_SELECTION_SEGMENT_ID_JSON_KEY = 'segmentId';
+const SEGMENT_SELECTION_ROOT_ID_JSON_KEY = 'rootId';
+const SEGMENT_SELECTION_POSITION_JSON_KEY = 'position';
+
 export interface SegmentSelection {
   segmentId: Uint64;
   rootId: Uint64;
   position: vec3;
+}
+
+export function restoreSegmentSelection(x: any): SegmentSelection {
+  return {
+    segmentId: Uint64.parseString(x[SEGMENT_SELECTION_SEGMENT_ID_JSON_KEY], 10),
+    rootId: Uint64.parseString(x[SEGMENT_SELECTION_ROOT_ID_JSON_KEY], 10),
+    position: verifyObjectProperty(x, SEGMENT_SELECTION_POSITION_JSON_KEY, verify3dVec)
+  };
 }
 
 export class ChunkedGraphChunkSource extends SliceViewChunkSource implements
@@ -193,6 +206,36 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     }
     const jsonIllegalSplitKey = 'illegal_split';
     return {supervoxelConnectedComponents, isSplitIllegal: jsonResp[jsonIllegalSplitKey]};
+  }
+
+  async findPath(first: SegmentSelection, second: SegmentSelection): Promise<number[][]> {
+    const {url} = this;
+    if (url === '') {
+      return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
+    }
+
+    const promise = authFetch(`${url}/graph/find_path`, {
+      method: 'POST',
+      body: JSON.stringify([
+        [String(first.segmentId), ...first.position.values()],
+        [String(second.segmentId), ...second.position.values()]
+      ])
+    });
+
+    const response = await this.withErrorMessage(promise, {
+      initialMessage: `Finding path between ${first.segmentId} and ${second.segmentId}`,
+      errorPrefix: 'Path finding failed: '
+    });
+    const jsonResponse = await response.json();
+    const supervoxelCentroidsKey = 'centroids_list';
+    const centroids = jsonResponse[supervoxelCentroidsKey];
+    const missingL2IdsKey = 'failed_l2_ids';
+    const missingL2Ids = jsonResponse[missingL2IdsKey];
+    if (missingL2Ids && missingL2Ids.length > 0) {
+      StatusMessage.showTemporaryMessage(
+          'Some level 2 meshes are missing, so the path shown may have a poor level of detail.');
+    }
+    return centroids;
   }
 
   draw() {}

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -214,7 +214,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/graph/find_path`, {
+    const promise = authFetch(`${url}/graph/find_path?int64_as_str=1`, {
       method: 'POST',
       body: JSON.stringify([
         [String(first.segmentId), ...first.position.values()],

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -46,6 +46,7 @@ import {formatIntegerPoint} from 'neuroglancer/util/spatial_units';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {WatchableVisibilityPriority} from 'neuroglancer/visibility_priority/frontend';
 import {makeCloseButton} from 'neuroglancer/widget/close_button';
+import {FindPathWidget} from 'neuroglancer/widget/find_path_widget';
 import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
 import {RangeWidget} from 'neuroglancer/widget/range';
 import {StackView, Tab} from 'neuroglancer/widget/tab_view';
@@ -286,6 +287,7 @@ export class GraphOperationLayerView extends Tab {
   multicutGroup = this.registerDisposer(new MinimizableGroupWidget('Multicut'));
   multicutOpacityGroup = this.registerDisposer(new MinimizableGroupWidget('Multicut Opacity'));
   timectrlGroup = this.registerDisposer(new MinimizableGroupWidget('Time Control'));
+  findPathGroup = this.registerDisposer(new MinimizableGroupWidget('Find Path'));
   timeWidget: TimeSegmentWidget|undefined;
 
   constructor(
@@ -410,6 +412,8 @@ export class GraphOperationLayerView extends Tab {
     displayState.timestamp.changed.add(disableConfirm);
     this.timectrlGroup.appendFlexibleChild(this.timeWidget.element);
     this.element.appendChild(this.timectrlGroup.element);
+
+    this.createPathFindingWidget();
 
     this.annotationListContainer.addEventListener('mouseleave', () => {
       this.annotationLayer.hoverState.value = undefined;
@@ -603,6 +607,13 @@ export class GraphOperationLayerView extends Tab {
       // Should never happen
       throw new Error('Multicut annotation not of type point');
     }
+  }
+
+  private createPathFindingWidget() {
+    this.registerDisposer(new FindPathWidget(
+        this.findPathGroup, this.wrapper, this.state, this.annotationLayer, this.voxelSize,
+        this.setSpatialCoordinates));
+    this.element.appendChild(this.findPathGroup.element);
   }
 }
 

--- a/src/neuroglancer/widget/find_path_widget.css
+++ b/src/neuroglancer/widget/find_path_widget.css
@@ -1,0 +1,23 @@
+#find-path-widget {
+  margin-top: 10px;
+}
+
+#find-path-label {
+  margin-top: 5px;
+}
+
+#find-path-source-target {
+  margin-top: 5px;
+}
+
+.find-path-source-or-target-prefix {
+  margin-right: 3px;
+}
+
+.find-path-source-or-target-item {
+  margin-top: 2px;
+}
+
+#path-finder-color-widget {
+  width: 60%;
+}

--- a/src/neuroglancer/widget/find_path_widget.ts
+++ b/src/neuroglancer/widget/find_path_widget.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright 2019 The Neuroglancer Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './find_path_widget.css';
+
+import {mat4, vec3} from 'gl-matrix';
+import {AnnotationType, getAnnotationTypeHandler, Line, Point} from 'neuroglancer/annotation';
+import {GraphOperationLayerState} from 'neuroglancer/graph/graph_operation_layer_state';
+import {PathFindingMarkerTool} from 'neuroglancer/graph/path_finder_state';
+import {VoxelSize} from 'neuroglancer/navigation_state';
+import {SegmentationUserLayerWithGraph} from 'neuroglancer/segmentation_user_layer_with_graph';
+import {StatusMessage} from 'neuroglancer/status';
+import {SelectedGraphOperationState} from 'neuroglancer/ui/graph_multicut';
+import {serializeColor} from 'neuroglancer/util/color';
+import {hsvToRgb, rgbToHsv} from 'neuroglancer/util/colorspace';
+import {Borrowed, RefCounted} from 'neuroglancer/util/disposable';
+import {removeChildren} from 'neuroglancer/util/dom';
+import {formatIntegerPoint} from 'neuroglancer/util/spatial_units';
+import {ColorWidget} from 'neuroglancer/widget/color';
+import {MinimizableGroupWidget} from 'neuroglancer/widget/minimizable_group';
+
+const tempVec3 = vec3.create();
+const hsv = new Float32Array(3);
+
+export class FindPathWidget extends RefCounted {
+  private findPathButton = document.createElement('button');
+
+  constructor(
+      private findPathGroup: Borrowed<MinimizableGroupWidget>,
+      private layer: Borrowed<SegmentationUserLayerWithGraph>,
+      private state: Borrowed<SelectedGraphOperationState>,
+      private annotationLayer: Borrowed<GraphOperationLayerState>,
+      private voxelSize: Borrowed<VoxelSize>,
+      private setSpatialCoordinates: (point: vec3) => void) {
+    super();
+    this.findPathGroup.element.id = 'find-path-widget';
+    this.createToolbox();
+    this.createPathUpdateEvent();
+  }
+
+  private get pathBetweenSupervoxels() {
+    return this.layer.pathFinderState.pathBetweenSupervoxels;
+  }
+
+  private get pathAnnotationColor() {
+    return this.layer.pathFinderState.pathAnnotationColor;
+  }
+
+  private createToolbox() {
+    const colorWidget = this.registerDisposer(new ColorWidget(this.pathAnnotationColor));
+    colorWidget.element.id = 'path-finder-color-widget';
+    const selectSourceAndTargetButton = document.createElement('button');
+    selectSourceAndTargetButton.textContent = getAnnotationTypeHandler(AnnotationType.POINT).icon;
+    selectSourceAndTargetButton.title = 'Select source and target';
+    selectSourceAndTargetButton.addEventListener('click', () => {
+      this.layer.tool.value = new PathFindingMarkerTool(this.layer);
+    });
+    let pathFound = false;
+    const {findPathButton} = this;
+    findPathButton.textContent = '✔️';
+    findPathButton.title = 'Find path';
+    findPathButton.addEventListener('click', () => {
+      if (!pathFound) {
+        if (!this.pathBetweenSupervoxels.ready()) {
+          StatusMessage.showTemporaryMessage('You must select a source and target to find a path');
+        } else {
+          const getSegmentSelectionFromPoint = (point: Point) => {
+            return {
+              segmentId: point.segments![0],
+              rootId: point.segments![1],
+              position: point.point
+            };
+          };
+          this.layer.chunkedGraphLayer!
+              .findPath(
+                  getSegmentSelectionFromPoint(this.pathBetweenSupervoxels.source!),
+                  getSegmentSelectionFromPoint(this.pathBetweenSupervoxels.target!))
+              .then((centroids) => {
+                pathFound = true;
+                findPathButton.title = 'Path found!';
+                StatusMessage.showTemporaryMessage('Path found!', 5000);
+                const path: Line[] = [];
+                for (let i = 0; i < centroids.length - 1; i++) {
+                  const line: Line = {
+                    pointA: vec3.fromValues(centroids[i][0], centroids[i][1], centroids[i][2]),
+                    pointB: vec3.fromValues(
+                        centroids[i + 1][0], centroids[i + 1][1], centroids[i + 1][2]),
+                    id: '',
+                    type: AnnotationType.LINE
+                  };
+                  path.push(line);
+                }
+                this.pathBetweenSupervoxels.setPath(path);
+              });
+        }
+      }
+    });
+    const clearButton = document.createElement('button');
+    clearButton.textContent = '❌';
+    clearButton.title = 'Clear path';
+    clearButton.addEventListener('click', () => {
+      pathFound = false;
+      findPathButton.title = 'Find path';
+      this.pathBetweenSupervoxels.clear();
+    });
+    const toolbox = document.createElement('div');
+    toolbox.classList.add('neuroglancer-graphoperation-toolbox');
+    toolbox.appendChild(colorWidget.element);
+    toolbox.appendChild(selectSourceAndTargetButton);
+    toolbox.appendChild(findPathButton);
+    toolbox.appendChild(clearButton);
+    this.findPathGroup.appendFixedChild(toolbox);
+  }
+
+  // Rotate color by 60 degrees on color wheel (to match up with annotation line
+  // segments)
+  private rotateColorBy60Degrees() {
+    const {pathAnnotationColor} = this;
+    rgbToHsv(
+        hsv, pathAnnotationColor.value[0], pathAnnotationColor.value[1],
+        pathAnnotationColor.value[2]);
+    hsv[0] -= 1 / 6;
+    if (hsv[0] < 0) {
+      hsv[0] += 1;
+    }
+    const rgb = hsv;
+    hsvToRgb(rgb, hsv[0], hsv[1], hsv[2]);
+    vec3.set(tempVec3, rgb[0], rgb[1], rgb[2]);
+    return serializeColor(tempVec3);
+  }
+
+  private createPathUpdateEvent() {
+    const {
+      pathAnnotationColor: findPathColor,
+      pathBetweenSupervoxels,
+      setSpatialCoordinates,
+      voxelSize,
+      findPathButton
+    } = this;
+    const findPathLabel = document.createElement('div');
+    findPathLabel.id = 'find-path-label';
+    const pathSourceAndTarget = document.createElement('ul');
+    pathSourceAndTarget.id = 'find-path-source-target';
+    const pathUpdateEvent = () => {
+      const {objectToGlobal} = this.annotationLayer;
+      removeChildren(pathSourceAndTarget);
+
+      const makePositionElement =
+          (position: HTMLElement, point: vec3, transform: mat4, source: boolean) => {
+            const spatialPoint = vec3.transformMat4(vec3.create(), point, transform);
+            const textPrefix = (source) ? 'Source: ' : 'Target: ';
+            const prefixElement = document.createElement('span');
+            prefixElement.classList.add('find-path-source-or-target-prefix');
+            prefixElement.textContent = textPrefix;
+            const positionText =
+                formatIntegerPoint(voxelSize.voxelFromSpatial(tempVec3, spatialPoint));
+            const element = document.createElement('span');
+            element.classList.add('neuroglancer-multicut-voxel-coordinates-link');
+            element.textContent = positionText;
+            if (source) {
+              element.style.color = findPathColor.toString();
+              this.registerDisposer(findPathColor.changed.add(() => {
+                element.style.color = findPathColor.toString();
+              }));
+            } else {
+              element.style.color = this.rotateColorBy60Degrees();
+              this.registerDisposer(findPathColor.changed.add(() => {
+                element.style.color = this.rotateColorBy60Degrees();
+              }));
+            }
+            element.title = `Center view on voxel coordinates ${positionText}.`;
+            element.addEventListener('click', () => {
+              setSpatialCoordinates(spatialPoint);
+            });
+            position.classList.add('find-path-source-or-target-item');
+            position.appendChild(prefixElement);
+            position.appendChild(element);
+          };
+
+      const makeAnnotationListElement = (point: vec3, transform: mat4, source: boolean) => {
+        const element = document.createElement('li');
+        element.title = 'Click to select, right click to recenter view.';
+
+        const icon = document.createElement('div');
+        icon.className = 'neuroglancer-annotation-icon';
+        icon.textContent = getAnnotationTypeHandler(AnnotationType.POINT).icon;
+        element.appendChild(icon);
+
+        const position = document.createElement('div');
+        position.className = 'neuroglancer-annotation-position';
+        makePositionElement(position, point, transform, source);
+        element.appendChild(position);
+
+        return element;
+      };
+
+      const annotationListElementCreator = (annotation: Point, source: boolean) => {
+        const point = annotation.point;
+        const element = makeAnnotationListElement(point, objectToGlobal, source);
+        pathSourceAndTarget.appendChild(element);
+        element.addEventListener('click', () => {
+          this.state.value = {id: annotation.id};
+        });
+        element.addEventListener('mouseup', (event: MouseEvent) => {
+          if (event.button === 2) {
+            vec3.transformMat4(tempVec3, point, objectToGlobal);
+            setSpatialCoordinates(tempVec3);
+          }
+        });
+      };
+      if (pathBetweenSupervoxels.source) {
+        annotationListElementCreator(pathBetweenSupervoxels.source, true);
+      }
+      if (pathBetweenSupervoxels.hasPath) {
+        findPathLabel.textContent = 'Path between source and target found.';
+        findPathButton.style.color = '#32CD32';
+      } else {
+        findPathLabel.textContent = 'Select a source and target to find a path.';
+        findPathButton.style.color = '#000000';
+      }
+      if (pathBetweenSupervoxels.target) {
+        annotationListElementCreator(pathBetweenSupervoxels.target, false);
+      }
+    };
+
+    this.registerDisposer(pathBetweenSupervoxels.changed.add(pathUpdateEvent));
+    pathUpdateEvent();
+    this.findPathGroup.appendFixedChild(findPathLabel);
+    this.findPathGroup.appendFlexibleChild(pathSourceAndTarget);
+  }
+}

--- a/src/neuroglancer/widget/find_path_widget.ts
+++ b/src/neuroglancer/widget/find_path_widget.ts
@@ -225,10 +225,10 @@ export class FindPathWidget extends RefCounted {
         annotationListElementCreator(pathBetweenSupervoxels.source, true);
       }
       if (pathBetweenSupervoxels.hasPath) {
-        findPathLabel.textContent = 'Path between source and target found.';
+        findPathLabel.textContent = 'Rough path between source and target found.';
         findPathButton.style.color = '#32CD32';
       } else {
-        findPathLabel.textContent = 'Select a source and target to find a path.';
+        findPathLabel.textContent = 'Select a source and target to find a (very rough) path between the two.';
         findPathButton.style.color = '#000000';
       }
       if (pathBetweenSupervoxels.target) {


### PR DESCRIPTION
This PR allows users to find paths between two different locations in a segment for graphene segmentation layers. It is useful to detect locations of mergers. It adds a widget to the graph tab by which the user puts down two points on a segment in either 2D or 3D. Neuroglancer then sends a request to the ChunkedGraph which returns a list of 3D coordinates that make up a path between the two locations in the segment. This path is displayed as line segment annotations.

Edit: Relevant ChunkedGraph PR is now live.