### PR TITLE
Add checkbox to ignore layer segment interactions

### DIFF
--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -215,7 +215,8 @@ class SegmentationLayerBase(Layer, _AnnotationLayerOptions):
     segments = wrapped_property('segments', typed_set(np.uint64))
     equivalences = wrapped_property('equivalences', uint64_equivalence_map)
     hide_segment_zero = hideSegmentZero = wrapped_property('hideSegmentZero', optional(bool, True))
-    ignore_segment_interactions = ignoreSegmentSelection = wrapped_property('ignoreSegmentInteractions', optional(bool, False))
+    ignore_segment_interactions = ignoreSegmentSelection = wrapped_property(
+        'ignoreSegmentInteractions', optional(bool, False))
     selected_alpha = selectedAlpha = wrapped_property('selectedAlpha', optional(float, 0.5))
     not_selected_alpha = notSelectedAlpha = wrapped_property('notSelectedAlpha', optional(float, 0))
     object_alpha = objectAlpha = wrapped_property('objectAlpha', optional(float, 1.0))

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -215,6 +215,7 @@ class SegmentationLayerBase(Layer, _AnnotationLayerOptions):
     segments = wrapped_property('segments', typed_set(np.uint64))
     equivalences = wrapped_property('equivalences', uint64_equivalence_map)
     hide_segment_zero = hideSegmentZero = wrapped_property('hideSegmentZero', optional(bool, True))
+    ignore_segment_selection = ignoreSegmentSelection = wrapped_property('ignoreSegmentSelection', optional(bool, False))
     selected_alpha = selectedAlpha = wrapped_property('selectedAlpha', optional(float, 0.5))
     not_selected_alpha = notSelectedAlpha = wrapped_property('notSelectedAlpha', optional(float, 0))
     object_alpha = objectAlpha = wrapped_property('objectAlpha', optional(float, 1.0))

--- a/python/neuroglancer/viewer_state.py
+++ b/python/neuroglancer/viewer_state.py
@@ -215,7 +215,7 @@ class SegmentationLayerBase(Layer, _AnnotationLayerOptions):
     segments = wrapped_property('segments', typed_set(np.uint64))
     equivalences = wrapped_property('equivalences', uint64_equivalence_map)
     hide_segment_zero = hideSegmentZero = wrapped_property('hideSegmentZero', optional(bool, True))
-    ignore_segment_selection = ignoreSegmentSelection = wrapped_property('ignoreSegmentSelection', optional(bool, False))
+    ignore_segment_interactions = ignoreSegmentSelection = wrapped_property('ignoreSegmentInteractions', optional(bool, False))
     selected_alpha = selectedAlpha = wrapped_property('selectedAlpha', optional(float, 0.5))
     not_selected_alpha = notSelectedAlpha = wrapped_property('notSelectedAlpha', optional(float, 0))
     object_alpha = objectAlpha = wrapped_property('objectAlpha', optional(float, 1.0))

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -431,6 +431,9 @@ export class SegmentationUserLayer extends Base {
   }
 
   handleAction(action: string) {
+    if (this.displayState.ignoreSegmentInteractions.value) {
+      return;
+    }
     switch (action) {
       case 'recolor': {
         this.displayState.segmentColorHash.randomize();
@@ -497,7 +500,7 @@ export class SegmentationUserLayer extends Base {
 
   selectSegment() {
     let {segmentSelectionState} = this.displayState;
-    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+    if (segmentSelectionState.hasSelectedSegment) {
       let segment = segmentSelectionState.selectedSegment;
       let {rootSegments} = this.displayState;
       if (rootSegments.has(segment)) {
@@ -523,7 +526,7 @@ export class SegmentationUserLayer extends Base {
 
   mergeSelectFirst() {
     const {segmentSelectionState} = this.displayState;
-    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+    if (segmentSelectionState.hasSelectedSegment) {
       lastSegmentSelection.assign(segmentSelectionState.rawSelectedSegment);
       StatusMessage.showTemporaryMessage(
           `Selected ${lastSegmentSelection} as source for merge. Pick a sink.`, 3000);
@@ -533,7 +536,7 @@ export class SegmentationUserLayer extends Base {
   mergeSelectSecond() {
     const {segmentSelectionState, segmentEquivalences, rootSegments, visibleSegments3D} =
         this.displayState;
-    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+    if (segmentSelectionState.hasSelectedSegment) {
       // Merge both selected segments
       const segment = segmentSelectionState.rawSelectedSegment.clone();
       segmentEquivalences.link(lastSegmentSelection, segment);

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -59,6 +59,7 @@ const NOT_SELECTED_ALPHA_JSON_KEY = 'notSelectedAlpha';
 const OBJECT_ALPHA_JSON_KEY = 'objectAlpha';
 const SATURATION_JSON_KEY = 'saturation';
 const HIDE_SEGMENT_ZERO_JSON_KEY = 'hideSegmentZero';
+const IGNORE_SEGMENT_SELECTION_JSON_KEY = 'ignoreSegmentSelection';
 const MESH_JSON_KEY = 'mesh';
 const SKELETONS_JSON_KEY = 'skeletons';
 const ROOT_SEGMENTS_JSON_KEY = 'segments';
@@ -92,6 +93,7 @@ export class SegmentationUserLayer extends Base {
     notSelectedAlpha: trackableAlphaValue(0),
     objectAlpha: trackableAlphaValue(1.0),
     hideSegmentZero: new TrackableBoolean(true, true),
+    ignoreSegmentSelection: new TrackableBoolean(false, false),
     rootSegments: Uint64Set.makeWithCounterpart(this.manager.worker),
     hiddenRootSegments: new Uint64Set(),
     visibleSegments2D: new Uint64Set(),
@@ -137,6 +139,7 @@ export class SegmentationUserLayer extends Base {
     this.displayState.notSelectedAlpha.changed.add(this.specificationChanged.dispatch);
     this.displayState.objectAlpha.changed.add(this.specificationChanged.dispatch);
     this.displayState.hideSegmentZero.changed.add(this.specificationChanged.dispatch);
+    this.displayState.ignoreSegmentSelection.changed.add(this.specificationChanged.dispatch);
     this.displayState.skeletonRenderingOptions.changed.add(this.specificationChanged.dispatch);
     this.displayState.segmentColorHash.changed.add(this.specificationChanged.dispatch);
     this.displayState.segmentStatedColors.changed.add(this.specificationChanged.dispatch);
@@ -158,6 +161,7 @@ export class SegmentationUserLayer extends Base {
     this.displayState.notSelectedAlpha.restoreState(specification[NOT_SELECTED_ALPHA_JSON_KEY]);
     this.displayState.objectAlpha.restoreState(specification[OBJECT_ALPHA_JSON_KEY]);
     this.displayState.hideSegmentZero.restoreState(specification[HIDE_SEGMENT_ZERO_JSON_KEY]);
+    this.displayState.ignoreSegmentSelection.restoreState(specification[IGNORE_SEGMENT_SELECTION_JSON_KEY]);
 
     const {skeletonRenderingOptions} = this.displayState;
     skeletonRenderingOptions.restoreState(specification[SKELETON_RENDERING_JSON_KEY]);
@@ -365,6 +369,7 @@ export class SegmentationUserLayer extends Base {
     x[SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
     x[HIDE_SEGMENT_ZERO_JSON_KEY] = this.displayState.hideSegmentZero.toJSON();
+    x[IGNORE_SEGMENT_SELECTION_JSON_KEY] = this.displayState.ignoreSegmentSelection.toJSON();
     x[COLOR_SEED_JSON_KEY] = this.displayState.segmentColorHash.toJSON();
     let {segmentStatedColors} = this.displayState;
     if (segmentStatedColors.size > 0) {
@@ -492,7 +497,7 @@ export class SegmentationUserLayer extends Base {
 
   selectSegment() {
     let {segmentSelectionState} = this.displayState;
-    if (segmentSelectionState.hasSelectedSegment) {
+    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentSelection.value)) {
       let segment = segmentSelectionState.selectedSegment;
       let {rootSegments} = this.displayState;
       if (rootSegments.has(segment)) {
@@ -689,6 +694,19 @@ class DisplayOptionsTab extends Tab {
     }));
     groupSegmentSelection.appendFlexibleChild(
         this.registerDisposer(this.visibleSegmentWidget).element);
+
+    {
+      const checkbox =
+          this.registerDisposer(new TrackableBooleanCheckbox(layer.displayState.ignoreSegmentSelection));
+      checkbox.element.className =
+          'neuroglancer-segmentation-dropdown-ignore-segment-selection neuroglancer-noselect';
+      const label = document.createElement('label');
+      label.className =
+          'neuroglancer-segmentation-dropdown-ignore-segment-selection neuroglancer-noselect';
+      label.appendChild(document.createTextNode('Ignore double-click for segment selection'));
+      label.appendChild(checkbox.element);
+      groupSegmentSelection.appendFixedChild(label);
+    }
 
     const maybeAddOmniSegmentWidget = () => {
       if (this.omniWidget || (!layer.segmentMetadata)) {

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -59,7 +59,7 @@ const NOT_SELECTED_ALPHA_JSON_KEY = 'notSelectedAlpha';
 const OBJECT_ALPHA_JSON_KEY = 'objectAlpha';
 const SATURATION_JSON_KEY = 'saturation';
 const HIDE_SEGMENT_ZERO_JSON_KEY = 'hideSegmentZero';
-const IGNORE_SEGMENT_SELECTION_JSON_KEY = 'ignoreSegmentSelection';
+const IGNORE_SEGMENT_INTERACTIONS_JSON_KEY = 'ignoreSegmentInteractions';
 const MESH_JSON_KEY = 'mesh';
 const SKELETONS_JSON_KEY = 'skeletons';
 const ROOT_SEGMENTS_JSON_KEY = 'segments';
@@ -93,7 +93,7 @@ export class SegmentationUserLayer extends Base {
     notSelectedAlpha: trackableAlphaValue(0),
     objectAlpha: trackableAlphaValue(1.0),
     hideSegmentZero: new TrackableBoolean(true, true),
-    ignoreSegmentSelection: new TrackableBoolean(false, false),
+    ignoreSegmentInteractions: new TrackableBoolean(false, false),
     rootSegments: Uint64Set.makeWithCounterpart(this.manager.worker),
     hiddenRootSegments: new Uint64Set(),
     visibleSegments2D: new Uint64Set(),
@@ -139,7 +139,7 @@ export class SegmentationUserLayer extends Base {
     this.displayState.notSelectedAlpha.changed.add(this.specificationChanged.dispatch);
     this.displayState.objectAlpha.changed.add(this.specificationChanged.dispatch);
     this.displayState.hideSegmentZero.changed.add(this.specificationChanged.dispatch);
-    this.displayState.ignoreSegmentSelection.changed.add(this.specificationChanged.dispatch);
+    this.displayState.ignoreSegmentInteractions.changed.add(this.specificationChanged.dispatch);
     this.displayState.skeletonRenderingOptions.changed.add(this.specificationChanged.dispatch);
     this.displayState.segmentColorHash.changed.add(this.specificationChanged.dispatch);
     this.displayState.segmentStatedColors.changed.add(this.specificationChanged.dispatch);
@@ -161,7 +161,7 @@ export class SegmentationUserLayer extends Base {
     this.displayState.notSelectedAlpha.restoreState(specification[NOT_SELECTED_ALPHA_JSON_KEY]);
     this.displayState.objectAlpha.restoreState(specification[OBJECT_ALPHA_JSON_KEY]);
     this.displayState.hideSegmentZero.restoreState(specification[HIDE_SEGMENT_ZERO_JSON_KEY]);
-    this.displayState.ignoreSegmentSelection.restoreState(specification[IGNORE_SEGMENT_SELECTION_JSON_KEY]);
+    this.displayState.ignoreSegmentInteractions.restoreState(specification[IGNORE_SEGMENT_INTERACTIONS_JSON_KEY]);
 
     const {skeletonRenderingOptions} = this.displayState;
     skeletonRenderingOptions.restoreState(specification[SKELETON_RENDERING_JSON_KEY]);
@@ -369,7 +369,7 @@ export class SegmentationUserLayer extends Base {
     x[SATURATION_JSON_KEY] = this.displayState.saturation.toJSON();
     x[OBJECT_ALPHA_JSON_KEY] = this.displayState.objectAlpha.toJSON();
     x[HIDE_SEGMENT_ZERO_JSON_KEY] = this.displayState.hideSegmentZero.toJSON();
-    x[IGNORE_SEGMENT_SELECTION_JSON_KEY] = this.displayState.ignoreSegmentSelection.toJSON();
+    x[IGNORE_SEGMENT_INTERACTIONS_JSON_KEY] = this.displayState.ignoreSegmentInteractions.toJSON();
     x[COLOR_SEED_JSON_KEY] = this.displayState.segmentColorHash.toJSON();
     let {segmentStatedColors} = this.displayState;
     if (segmentStatedColors.size > 0) {
@@ -497,7 +497,7 @@ export class SegmentationUserLayer extends Base {
 
   selectSegment() {
     let {segmentSelectionState} = this.displayState;
-    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentSelection.value)) {
+    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
       let segment = segmentSelectionState.selectedSegment;
       let {rootSegments} = this.displayState;
       if (rootSegments.has(segment)) {
@@ -523,7 +523,7 @@ export class SegmentationUserLayer extends Base {
 
   mergeSelectFirst() {
     const {segmentSelectionState} = this.displayState;
-    if (segmentSelectionState.hasSelectedSegment) {
+    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
       lastSegmentSelection.assign(segmentSelectionState.rawSelectedSegment);
       StatusMessage.showTemporaryMessage(
           `Selected ${lastSegmentSelection} as source for merge. Pick a sink.`, 3000);
@@ -533,7 +533,7 @@ export class SegmentationUserLayer extends Base {
   mergeSelectSecond() {
     const {segmentSelectionState, segmentEquivalences, rootSegments, visibleSegments3D} =
         this.displayState;
-    if (segmentSelectionState.hasSelectedSegment) {
+    if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
       // Merge both selected segments
       const segment = segmentSelectionState.rawSelectedSegment.clone();
       segmentEquivalences.link(lastSegmentSelection, segment);
@@ -697,13 +697,13 @@ class DisplayOptionsTab extends Tab {
 
     {
       const checkbox =
-          this.registerDisposer(new TrackableBooleanCheckbox(layer.displayState.ignoreSegmentSelection));
+          this.registerDisposer(new TrackableBooleanCheckbox(layer.displayState.ignoreSegmentInteractions));
       checkbox.element.className =
-          'neuroglancer-segmentation-dropdown-ignore-segment-selection neuroglancer-noselect';
+          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
       const label = document.createElement('label');
       label.className =
-          'neuroglancer-segmentation-dropdown-ignore-segment-selection neuroglancer-noselect';
-      label.appendChild(document.createTextNode('Ignore double-click for segment selection'));
+          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
+      label.appendChild(document.createTextNode('Ignore segment interactions'));
       label.appendChild(checkbox.element);
       groupSegmentSelection.appendFixedChild(label);
     }

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -230,6 +230,9 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
     }
 
     handleAction(action: string) {
+      if (this.displayState.ignoreSegmentInteractions.value) {
+        return;
+      }
       switch (action) {
         case 'clear-segments': {
           this.displayState.rootSegments.clear();
@@ -282,7 +285,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     selectSegment() {
       let {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+      if (segmentSelectionState.hasSelectedSegment) {
         let segment = segmentSelectionState.selectedSegment;
         let {rootSegments, timestamp} = this.displayState;
         let tsValue = (timestamp.value !== '') ? timestamp.value : void (0);
@@ -328,7 +331,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     mergeSelectFirst() {
       const {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+      if (segmentSelectionState.hasSelectedSegment) {
         lastSegmentSelection.segmentId.assign(segmentSelectionState.rawSelectedSegment);
         lastSegmentSelection.rootId.assign(segmentSelectionState.selectedSegment);
         vec3.transformMat4(
@@ -342,7 +345,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     mergeSelectSecond() {
       const {segmentSelectionState, rootSegments} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+      if (segmentSelectionState.hasSelectedSegment) {
         const currentSegmentSelection: SegmentSelection = {
           segmentId: segmentSelectionState.rawSelectedSegment.clone(),
           rootId: segmentSelectionState.selectedSegment.clone(),
@@ -372,7 +375,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     splitSelectFirst() {
       const {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+      if (segmentSelectionState.hasSelectedSegment) {
         lastSegmentSelection.segmentId.assign(segmentSelectionState.rawSelectedSegment);
         lastSegmentSelection.rootId.assign(segmentSelectionState.selectedSegment);
         vec3.transformMat4(
@@ -386,7 +389,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     splitSelectSecond() {
       const {segmentSelectionState, rootSegments} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
+      if (segmentSelectionState.hasSelectedSegment) {
         const currentSegmentSelection: SegmentSelection = {
           segmentId: segmentSelectionState.rawSelectedSegment.clone(),
           rootId: segmentSelectionState.selectedSegment.clone(),

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -230,7 +230,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
     }
 
     handleAction(action: string) {
-      if (this.displayState.ignoreSegmentInteractions.value) {
+      if (this.ignoreSegmentInteractions.value) {
         return;
       }
       switch (action) {

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -282,7 +282,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     selectSegment() {
       let {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment) {
+      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
         let segment = segmentSelectionState.selectedSegment;
         let {rootSegments, timestamp} = this.displayState;
         let tsValue = (timestamp.value !== '') ? timestamp.value : void (0);
@@ -328,7 +328,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     mergeSelectFirst() {
       const {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment) {
+      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
         lastSegmentSelection.segmentId.assign(segmentSelectionState.rawSelectedSegment);
         lastSegmentSelection.rootId.assign(segmentSelectionState.selectedSegment);
         vec3.transformMat4(
@@ -342,7 +342,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     mergeSelectSecond() {
       const {segmentSelectionState, rootSegments} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment) {
+      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
         const currentSegmentSelection: SegmentSelection = {
           segmentId: segmentSelectionState.rawSelectedSegment.clone(),
           rootId: segmentSelectionState.selectedSegment.clone(),
@@ -372,7 +372,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     splitSelectFirst() {
       const {segmentSelectionState} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment) {
+      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
         lastSegmentSelection.segmentId.assign(segmentSelectionState.rawSelectedSegment);
         lastSegmentSelection.rootId.assign(segmentSelectionState.selectedSegment);
         vec3.transformMat4(
@@ -386,7 +386,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
 
     splitSelectSecond() {
       const {segmentSelectionState, rootSegments} = this.displayState;
-      if (segmentSelectionState.hasSelectedSegment) {
+      if (segmentSelectionState.hasSelectedSegment && !(this.displayState.ignoreSegmentInteractions.value)) {
         const currentSegmentSelection: SegmentSelection = {
           segmentId: segmentSelectionState.rawSelectedSegment.clone(),
           rootId: segmentSelectionState.selectedSegment.clone(),

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -53,6 +53,7 @@ export interface SliceViewSegmentationDisplayState extends SegmentationDisplaySt
   notSelectedAlpha: TrackableAlphaValue;
   volumeSourceOptions?: VolumeSourceOptions;
   hideSegmentZero: TrackableBoolean;
+  ignoreSegmentSelection: TrackableBoolean;
   multicutSegments?: Uint64Set;
   performingMulticut?: TrackableBoolean;
 }
@@ -93,6 +94,10 @@ export class SegmentationRenderLayer extends RenderLayer {
       this.redrawNeeded.dispatch();
     }));
     this.registerDisposer(displayState.hideSegmentZero.changed.add(() => {
+      this.redrawNeeded.dispatch();
+      this.shaderGetter.invalidateShader();
+    }));
+    this.registerDisposer(displayState.ignoreSegmentSelection.changed.add(() => {
       this.redrawNeeded.dispatch();
       this.shaderGetter.invalidateShader();
     }));

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -53,7 +53,7 @@ export interface SliceViewSegmentationDisplayState extends SegmentationDisplaySt
   notSelectedAlpha: TrackableAlphaValue;
   volumeSourceOptions?: VolumeSourceOptions;
   hideSegmentZero: TrackableBoolean;
-  ignoreSegmentSelection: TrackableBoolean;
+  ignoreSegmentInteractions: TrackableBoolean;
   multicutSegments?: Uint64Set;
   performingMulticut?: TrackableBoolean;
 }
@@ -97,7 +97,7 @@ export class SegmentationRenderLayer extends RenderLayer {
       this.redrawNeeded.dispatch();
       this.shaderGetter.invalidateShader();
     }));
-    this.registerDisposer(displayState.ignoreSegmentSelection.changed.add(() => {
+    this.registerDisposer(displayState.ignoreSegmentInteractions.changed.add(() => {
       this.redrawNeeded.dispatch();
       this.shaderGetter.invalidateShader();
     }));

--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -53,7 +53,6 @@ export interface SliceViewSegmentationDisplayState extends SegmentationDisplaySt
   notSelectedAlpha: TrackableAlphaValue;
   volumeSourceOptions?: VolumeSourceOptions;
   hideSegmentZero: TrackableBoolean;
-  ignoreSegmentInteractions: TrackableBoolean;
   multicutSegments?: Uint64Set;
   performingMulticut?: TrackableBoolean;
 }
@@ -94,10 +93,6 @@ export class SegmentationRenderLayer extends RenderLayer {
       this.redrawNeeded.dispatch();
     }));
     this.registerDisposer(displayState.hideSegmentZero.changed.add(() => {
-      this.redrawNeeded.dispatch();
-      this.shaderGetter.invalidateShader();
-    }));
-    this.registerDisposer(displayState.ignoreSegmentInteractions.changed.add(() => {
       this.redrawNeeded.dispatch();
       this.shaderGetter.invalidateShader();
     }));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2455512/66412760-25e2e780-e9c4-11e9-8e77-5c4876b8aa37.png)

Adds a checkbox to the "Segment Selection" section which, when selected, disables the ability to double-click to select/deselect a segment.