### PR TITLE
Options to not load meshes/skeletons for single layers

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,4 +1,4 @@
-### October 22 2019
-## Sync with google/neuroglancer
-* Thanks to @jbms and @lutzroeder
-* Detailed changelog on [github.com/google/neuroglancer](https://github.com/google/neuroglancer/compare/efd558799a54db917498819798d1e66e98bfbd71...google:ebb893928bc00ee61508f2c6ce23e01fe0e650c9)
+### October 30 2019
+## Option to not load meshes for single layers
+* Under 3D Visualization, uncheck "Load layer meshes (requires refresh)" then refresh the page to stop that mesh's layers from being loaded.
+* The same option exists for skeletons.

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -690,30 +690,6 @@ class DisplayOptionsTab extends Tab {
 
     {
       const checkbox =
-          this.registerDisposer(new TrackableBooleanCheckbox(layer.displayState.hideSegmentZero));
-      checkbox.element.className =
-          'neuroglancer-segmentation-dropdown-hide-segment-zero neuroglancer-noselect';
-      const label = document.createElement('label');
-      label.className =
-          'neuroglancer-segmentation-dropdown-hide-segment-zero neuroglancer-noselect';
-      label.appendChild(document.createTextNode('Hide segment ID 0'));
-      label.appendChild(checkbox.element);
-      groupSegmentSelection.appendFixedChild(label);
-    }
-
-    this.addSegmentWidget.element.classList.add('add-segment');
-    this.addSegmentWidget.element.title = 'Add one or more segment IDs';
-    groupSegmentSelection.appendFixedChild(this.registerDisposer(this.addSegmentWidget).element);
-    this.registerDisposer(this.addSegmentWidget.valuesEntered.add((values: Uint64[]) => {
-      for (const value of values) {
-        this.layer.displayState.rootSegments.add(value);
-      }
-    }));
-    groupSegmentSelection.appendFlexibleChild(
-        this.registerDisposer(this.visibleSegmentWidget).element);
-
-    {
-      const checkbox =
           this.registerDisposer(new TrackableBooleanCheckbox(layer.ignoreSegmentInteractions));
       checkbox.element.className =
           'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
@@ -737,6 +713,30 @@ class DisplayOptionsTab extends Tab {
       label.appendChild(checkbox.element);
       groupSegmentSelection.appendFixedChild(label);
     }
+
+    {
+      const checkbox =
+          this.registerDisposer(new TrackableBooleanCheckbox(layer.displayState.hideSegmentZero));
+      checkbox.element.className =
+          'neuroglancer-segmentation-dropdown-hide-segment-zero neuroglancer-noselect';
+      const label = document.createElement('label');
+      label.className =
+          'neuroglancer-segmentation-dropdown-hide-segment-zero neuroglancer-noselect';
+      label.appendChild(document.createTextNode('Hide segment ID 0'));
+      label.appendChild(checkbox.element);
+      groupSegmentSelection.appendFixedChild(label);
+    }
+
+    this.addSegmentWidget.element.classList.add('add-segment');
+    this.addSegmentWidget.element.title = 'Add one or more segment IDs';
+    groupSegmentSelection.appendFixedChild(this.registerDisposer(this.addSegmentWidget).element);
+    this.registerDisposer(this.addSegmentWidget.valuesEntered.add((values: Uint64[]) => {
+      for (const value of values) {
+        this.layer.displayState.rootSegments.add(value);
+      }
+    }));
+    groupSegmentSelection.appendFlexibleChild(
+        this.registerDisposer(this.visibleSegmentWidget).element);
 
     const maybeAddOmniSegmentWidget = () => {
       if (this.omniWidget || (!layer.segmentMetadata)) {

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -690,19 +690,6 @@ class DisplayOptionsTab extends Tab {
 
     {
       const checkbox =
-          this.registerDisposer(new TrackableBooleanCheckbox(layer.ignoreSegmentInteractions));
-      checkbox.element.className =
-          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
-      const label = document.createElement('label');
-      label.className =
-          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
-      label.appendChild(document.createTextNode('Ignore segment interactions'));
-      label.appendChild(checkbox.element);
-      groupSegmentSelection.appendFixedChild(label);
-    }
-
-    {
-      const checkbox =
           this.registerDisposer(new TrackableBooleanCheckbox(layer.loadMeshes));
       checkbox.element.className =
           'neuroglancer-segmentation-dropdown-load-meshes neuroglancer-noselect';
@@ -710,6 +697,19 @@ class DisplayOptionsTab extends Tab {
       label.className =
           'neuroglancer-segmentation-dropdown-load-meshes neuroglancer-noselect';
       label.appendChild(document.createTextNode('Load layer meshes (requires refresh)'));
+      label.appendChild(checkbox.element);
+      group3D.appendFixedChild(label);
+    }
+
+    {
+      const checkbox =
+          this.registerDisposer(new TrackableBooleanCheckbox(layer.ignoreSegmentInteractions));
+      checkbox.element.className =
+          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
+      const label = document.createElement('label');
+      label.className =
+          'neuroglancer-segmentation-dropdown-ignore-segment-interactions neuroglancer-noselect';
+      label.appendChild(document.createTextNode('Ignore segment interactions'));
       label.appendChild(checkbox.element);
       groupSegmentSelection.appendFixedChild(label);
     }


### PR DESCRIPTION
Under 3D Visualization, uncheck "Load layer meshes (requires refresh)" then refresh the page to stop that mesh's layers from being loaded. The same option exists for skeletons.

Fixes https://github.com/seung-lab/neuroglancer/issues/295.