### PR TITLE
Don't lose focus when moving mouse off coordinates

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,4 +1,4 @@
-### October 30 2019
-## Option to not load meshes for single layers
-* Under 3D Visualization, uncheck "Load layer meshes (requires refresh)" then refresh the page to stop that mesh's layers from being loaded.
-* The same option exists for skeletons.
+### October 31 2019
+## Keep focus when moving mouse off of textboxes
+* For the navigation coordinates at the top, the shader code, and the transformation matrix, focus will no longer be lost when moving the mouse off the text and onto another area.
+* Elements will still be unfocused when clicking on another panel.

--- a/src/neuroglancer/util/automatic_focus.ts
+++ b/src/neuroglancer/util/automatic_focus.ts
@@ -17,7 +17,6 @@
 import debounce from 'lodash/debounce';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import LinkedListOperations from 'neuroglancer/util/linked_list.0';
-import { PositionWidget } from '../widget/position_widget';
 
 class AutomaticFocusList {
   next0: AutomaticallyFocusedElement|null;
@@ -49,6 +48,8 @@ window.addEventListener('blur', () => {
 }, true);
 
 export class AutomaticallyFocusedElement extends RefCounted {
+  static anyTextboxSelected: boolean;
+
   prev0: AutomaticallyFocusedElement|null = null;
   next0: AutomaticallyFocusedElement|null = null;
 
@@ -61,8 +62,8 @@ export class AutomaticallyFocusedElement extends RefCounted {
       // Never steal focus from descendant.
       return;
     }
-    if (PositionWidget.anySelected) {
-      // Don't steal focus from a position widget currently being typed in.
+    if (AutomaticallyFocusedElement.anyTextboxSelected) {
+      // Don't steal focus from a widget currently being typed in.
       return;
     }
     if (activeElement != null &&
@@ -84,7 +85,7 @@ export class AutomaticallyFocusedElement extends RefCounted {
     });
     this.registerEventListener(element, 'mousedown', () => {
       if (element.classList.contains('neuroglancer-panel')) {
-        PositionWidget.anySelected = false;
+        AutomaticallyFocusedElement.anyTextboxSelected = false;
         this.scheduleUpdateFocus();
       }
     });

--- a/src/neuroglancer/util/automatic_focus.ts
+++ b/src/neuroglancer/util/automatic_focus.ts
@@ -17,6 +17,7 @@
 import debounce from 'lodash/debounce';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import LinkedListOperations from 'neuroglancer/util/linked_list.0';
+import { PositionWidget } from '../widget/position_widget';
 
 class AutomaticFocusList {
   next0: AutomaticallyFocusedElement|null;
@@ -58,6 +59,10 @@ export class AutomaticallyFocusedElement extends RefCounted {
     const {element} = this;
     if (element.contains(activeElement)) {
       // Never steal focus from descendant.
+      return;
+    }
+    if (PositionWidget.anySelected) {
+      // Don't steal focus from a position widget currently being typed in.
       return;
     }
     if (activeElement != null &&

--- a/src/neuroglancer/util/automatic_focus.ts
+++ b/src/neuroglancer/util/automatic_focus.ts
@@ -82,6 +82,12 @@ export class AutomaticallyFocusedElement extends RefCounted {
     this.registerEventListener(element, 'mouseleave', () => {
       this.scheduleUpdateFocus.cancel();
     });
+    this.registerEventListener(element, 'mousedown', () => {
+      if (element.classList.contains('neuroglancer-panel')) {
+        PositionWidget.anySelected = false;
+        this.scheduleUpdateFocus();
+      }
+    });
     // Insert at the end of the list.
     LinkedListOperations.insertBefore(<any>automaticFocusList, this);
     this.registerEventListener(element, 'focus', () => {

--- a/src/neuroglancer/widget/coordinate_transform.ts
+++ b/src/neuroglancer/widget/coordinate_transform.ts
@@ -21,6 +21,7 @@
 import './coordinate_transform.css';
 
 import {CoordinateTransform} from 'neuroglancer/coordinate_transform';
+import {AutomaticallyFocusedElement} from 'neuroglancer/util/automatic_focus';
 import {float32ToString} from 'neuroglancer/util/float32_to_string';
 import {Tab} from 'neuroglancer/widget/tab_view';
 
@@ -40,7 +41,11 @@ export class CoordinateTransformTab extends Tab {
     this.registerDisposer(transform.changed.add(() => this.updateView()));
     this.registerDisposer(this.visibility.changed.add(() => this.updateView()));
     textArea.addEventListener('change', () => this.updateModel());
-    textArea.addEventListener('blur', () => this.updateModel());
+    textArea.addEventListener('focus', () => AutomaticallyFocusedElement.anyTextboxSelected = true);
+    textArea.addEventListener('blur', () => {
+      this.updateModel();
+      AutomaticallyFocusedElement.anyTextboxSelected = false;
+    });
     textArea.title = 'Homogeneous transformation matrix';
     textArea.rows = 3;
     const resetButton = document.createElement('button');

--- a/src/neuroglancer/widget/position_widget.ts
+++ b/src/neuroglancer/widget/position_widget.ts
@@ -18,6 +18,7 @@ import {MouseSelectionState} from 'neuroglancer/layer';
 import {SpatialPosition, VoxelSize} from 'neuroglancer/navigation_state';
 import {StatusMessage} from 'neuroglancer/status';
 import {animationFrameDebounce} from 'neuroglancer/util/animation_frame_debounce';
+import {AutomaticallyFocusedElement} from 'neuroglancer/util/automatic_focus';
 import {setClipboard} from 'neuroglancer/util/clipboard';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {removeChildren, removeFromParent} from 'neuroglancer/util/dom';
@@ -48,8 +49,6 @@ const normalizedPrefixString = '  ';
 const normalizedSeparatorString = ',   ';
 
 export class PositionWidget extends RefCounted {
-  static anySelected: boolean;
-  
   element = document.createElement('div');
   inputContainer = document.createElement('div');
   inputElement = document.createElement('input');
@@ -107,7 +106,7 @@ export class PositionWidget extends RefCounted {
     this.registerEventListener(inputElement, 'change', () => this.updatePosition());
     this.registerEventListener(inputElement, 'blur', () => {
       this.updatePosition();
-      PositionWidget.anySelected = false;
+      AutomaticallyFocusedElement.anyTextboxSelected = false;
     });
     this.registerEventListener(inputElement, 'input', () => this.cleanInput());
     this.registerEventListener(inputElement, 'keydown', this.updateHintScrollPosition);
@@ -125,7 +124,7 @@ export class PositionWidget extends RefCounted {
     let wasFocused = false;
     this.registerEventListener(inputElement, 'mousedown', () => {
       wasFocused = document.activeElement === inputElement;
-      PositionWidget.anySelected = true;
+      AutomaticallyFocusedElement.anyTextboxSelected = true;
     });
 
     this.registerDisposer(
@@ -189,7 +188,7 @@ export class PositionWidget extends RefCounted {
     this.registerDisposer(registerActionListener(inputElement, 'cancel', () => {
       this.updateView();
       this.inputElement.blur();
-      PositionWidget.anySelected = false;
+      AutomaticallyFocusedElement.anyTextboxSelected = false;
     }));
 
     this.registerDisposer(

--- a/src/neuroglancer/widget/position_widget.ts
+++ b/src/neuroglancer/widget/position_widget.ts
@@ -48,6 +48,8 @@ const normalizedPrefixString = '  ';
 const normalizedSeparatorString = ',   ';
 
 export class PositionWidget extends RefCounted {
+  static anySelected: boolean;
+  
   element = document.createElement('div');
   inputContainer = document.createElement('div');
   inputElement = document.createElement('input');
@@ -103,7 +105,10 @@ export class PositionWidget extends RefCounted {
     this.registerDisposer(new MouseEventBinder(inputElement, inputEventMap));
 
     this.registerEventListener(inputElement, 'change', () => this.updatePosition());
-    this.registerEventListener(inputElement, 'blur', () => this.updatePosition());
+    this.registerEventListener(inputElement, 'blur', () => {
+      this.updatePosition();
+      PositionWidget.anySelected = false;
+    });
     this.registerEventListener(inputElement, 'input', () => this.cleanInput());
     this.registerEventListener(inputElement, 'keydown', this.updateHintScrollPosition);
     this.registerEventListener(inputElement, 'copy', (event: ClipboardEvent) => {
@@ -120,6 +125,7 @@ export class PositionWidget extends RefCounted {
     let wasFocused = false;
     this.registerEventListener(inputElement, 'mousedown', () => {
       wasFocused = document.activeElement === inputElement;
+      PositionWidget.anySelected = true;
     });
 
     this.registerDisposer(
@@ -183,6 +189,7 @@ export class PositionWidget extends RefCounted {
     this.registerDisposer(registerActionListener(inputElement, 'cancel', () => {
       this.updateView();
       this.inputElement.blur();
+      PositionWidget.anySelected = false;
     }));
 
     this.registerDisposer(

--- a/src/neuroglancer/widget/shader_code_widget.ts
+++ b/src/neuroglancer/widget/shader_code_widget.ts
@@ -22,6 +22,7 @@ import 'codemirror/addon/lint/lint.css';
 import CodeMirror from 'codemirror';
 import debounce from 'lodash/debounce';
 import {WatchableValue} from 'neuroglancer/trackable_value';
+import {AutomaticallyFocusedElement} from 'neuroglancer/util/automatic_focus';
 import {RefCounted} from 'neuroglancer/util/disposable';
 import {removeFromParent} from 'neuroglancer/util/dom';
 import {WatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
@@ -69,6 +70,8 @@ export class ShaderCodeWidget extends RefCounted {
       this.setValidState(undefined);
       this.debouncedValueUpdater();
     });
+    this.textEditor.on('focus', () => AutomaticallyFocusedElement.anyTextboxSelected = true);
+    this.textEditor.on('blur', () => AutomaticallyFocusedElement.anyTextboxSelected = false);
     this.registerDisposer(this.state.fragmentMain.changed.add(() => {
       if (!this.changingValue) {
         this.textEditor.setValue(this.state.fragmentMain.value);


### PR DESCRIPTION
Previously when moving the mouse off of the coordinates (position widget) at the top, it would lose focus (so you had to hold your mouse there while editing it). With this change, you can move your mouse elsewhere, and only when you click on another panel will the coordinates get deselected.

Partially addresses https://github.com/seung-lab/neuroglancer/issues/361.