### PR TITLE
fix: add 'neuroglancer_legacy_mesh' as an explicit mesh info type

### DIFF
--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -283,10 +283,13 @@ function parseTransform(data: any): mat4 {
   });
 }
 
-function parseMeshMetadata(data: any): MultiscaleMeshMetadata {
+function parseMeshMetadata(data: any): MultiscaleMeshMetadata|undefined {
   verifyObject(data);
   const t = verifyObjectProperty(data, '@type', verifyString);
-  if (t !== 'neuroglancer_multilod_draco') {
+  if (t === 'neuroglancer_legacy_mesh') {
+    return undefined;
+  }
+  else if (t !== 'neuroglancer_multilod_draco') {
     throw new Error(`Unsupported mesh type: ${JSON.stringify(t)}`);
   }
   const lodScaleMultiplier =

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -207,10 +207,13 @@ function parseTransform(data: any): mat4 {
   });
 }
 
-function parseMeshMetadata(data: any): MultiscaleMeshMetadata {
+function parseMeshMetadata(data: any): MultiscaleMeshMetadata|undefined {
   verifyObject(data);
   const t = verifyObjectProperty(data, '@type', verifyString);
-  if (t !== 'neuroglancer_multilod_draco') {
+  if (t === 'neuroglancer_legacy_mesh') {
+    return undefined;
+  }
+  else if (t !== 'neuroglancer_multilod_draco') {
     throw new Error(`Unsupported mesh type: ${JSON.stringify(t)}`);
   }
   const lodScaleMultiplier =


### PR DESCRIPTION
Currently, neuroglancer treats missing mesh info files as legacy
format, but we found that it is necessary to add some attributes
to mesh info files in order to deduplicate chunk boundaries. However,
this leaves us with no way to read legacy formats. Thus, we add
neuroglancer_legacy_mesh as an explicit type to enable continued use.