### PR TITLE
Add checkbox for annotation selection displaying segmentation

### DIFF
--- a/src/neuroglancer/annotation/annotation_layer_state.ts
+++ b/src/neuroglancer/annotation/annotation_layer_state.ts
@@ -44,6 +44,7 @@ export class AnnotationLayerState extends RefCounted {
   segmentationState: WatchableValue<SegmentationDisplayState|undefined|null>;
   filterBySegmentation: TrackableBoolean;
   annotationJumpingDisplaysSegmentation = new TrackableBoolean(false);
+  annotationSelectionDisplaysSegmentation = new TrackableBoolean(false);
   selectedAnnotationTagId = new TrackableValue<number>(0, verifyNonnegativeInt, 0);
 
   private transformCacheGeneration = -1;
@@ -77,6 +78,8 @@ export class AnnotationLayerState extends RefCounted {
     role?: RenderLayerRole, color: TrackableRGB, fillOpacity: TrackableAlphaValue,
     segmentationState?: WatchableValue<SegmentationDisplayState|undefined|null>,
     filterBySegmentation?: TrackableBoolean,
+    annotationJumpingDispaysSegmentationInitialValue?: boolean,
+    annotationSelectionDisplaysSegmentationInitialValue?: boolean
   }) {
     super();
     const {
@@ -88,6 +91,8 @@ export class AnnotationLayerState extends RefCounted {
       fillOpacity,
       segmentationState = new WatchableValue(null),
       filterBySegmentation = new TrackableBoolean(false),
+      annotationJumpingDispaysSegmentationInitialValue,
+      annotationSelectionDisplaysSegmentationInitialValue
     } = options;
     this.transform = transform;
     this.source = this.registerDisposer(source);
@@ -97,5 +102,11 @@ export class AnnotationLayerState extends RefCounted {
     this.fillOpacity = fillOpacity;
     this.segmentationState = segmentationState;
     this.filterBySegmentation = filterBySegmentation;
+    if (annotationJumpingDispaysSegmentationInitialValue) {
+      this.annotationJumpingDisplaysSegmentation.value = true;
+    }
+    if (annotationSelectionDisplaysSegmentationInitialValue) {
+      this.annotationSelectionDisplaysSegmentation.value = true;
+    }
   }
 }

--- a/src/neuroglancer/annotation/annotation_layer_view.ts
+++ b/src/neuroglancer/annotation/annotation_layer_view.ts
@@ -249,6 +249,15 @@ export class AnnotationLayerView extends Tab {
     this.groupVisualization.appendFixedChild(label);
   }
 
+  private selectionShowsSegmentationCheckbox() {
+    const selectionShowsSegmentationCheckbox = this.registerDisposer(
+        new TrackableBooleanCheckbox(this.annotationLayer.annotationSelectionDisplaysSegmentation));
+    const label = document.createElement('label');
+    label.textContent = 'Annotation selection shows segmentation: ';
+    label.appendChild(selectionShowsSegmentationCheckbox.element);
+    this.groupVisualization.appendFixedChild(label);
+  }
+
   private filterAnnotationByTagControl() {
     const annotationTagFilter = document.createElement('select');
     const {source} = this.annotationLayer;
@@ -360,6 +369,7 @@ export class AnnotationLayerView extends Tab {
     // Visualization Group
     this.addOpacitySlider();
     this.bracketShortcutCheckbox();
+    this.selectionShowsSegmentationCheckbox();
     this.filterAnnotationByTagControl();
     // Annotations Group
     this.addColorPicker();
@@ -751,7 +761,9 @@ export class AnnotationLayerView extends Tab {
 
     const position = document.createElement('div');
     position.className = 'neuroglancer-annotation-position';
-    getPositionSummary(position, annotation, transform, this.voxelSize, this.setSpatialCoordinates);
+    getPositionSummary(
+        position, annotation, transform, this.voxelSize, this.setSpatialCoordinates,
+        this.annotationLayer);
     element.appendChild(position);
     if (annotation.parentId) {
       element.dataset.parent = annotation.parentId;

--- a/src/neuroglancer/annotation/user_layer.ts
+++ b/src/neuroglancer/annotation/user_layer.ts
@@ -103,6 +103,9 @@ const VOXEL_SIZE_JSON_KEY = 'voxelSize';
 const SOURCE_JSON_KEY = 'source';
 const LINKED_SEGMENTATION_LAYER_JSON_KEY = 'linkedSegmentationLayer';
 const FILTER_BY_SEGMENTATION_JSON_KEY = 'filterBySegmentation';
+const BRACKET_SHORTCUTS_SHOW_SEGMENTATION_KEY = 'bracketShortcutsShowSegmentation';
+const ANNOTATION_SELECTION_SHOWS_SEGMENTATION_KEY = 'annotationSelectionShowsSegmentation';
+
 const Base = UserLayerWithAnnotationsMixin(UserLayerWithCoordinateTransformMixin(UserLayer));
 export class AnnotationUserLayer extends Base {
   localAnnotations = this.registerDisposer(new LocalAnnotationSource());
@@ -170,7 +173,11 @@ export class AnnotationUserLayer extends Base {
           this.annotationLayerState.value = new AnnotationLayerState({
             transform: derivedTransform,
             source: this.localAnnotations.addRef(),
-            ...this.getAnnotationRenderOptions()
+            ...this.getAnnotationRenderOptions(),
+            annotationJumpingDispaysSegmentationInitialValue:
+                specification[BRACKET_SHORTCUTS_SHOW_SEGMENTATION_KEY],
+            annotationSelectionDisplaysSegmentationInitialValue:
+                specification[ANNOTATION_SELECTION_SHOWS_SEGMENTATION_KEY]
           });
           voxelSizeValid = true;
         }
@@ -205,8 +212,15 @@ export class AnnotationUserLayer extends Base {
             if (this.wasDisposed) {
               return;
             }
-            this.annotationLayerState.value = new AnnotationLayerState(
-                {transform: this.transform, source, ...this.getAnnotationRenderOptions()});
+            this.annotationLayerState.value = new AnnotationLayerState({
+              transform: this.transform,
+              source,
+              ...this.getAnnotationRenderOptions(),
+              annotationJumpingDispaysSegmentationInitialValue:
+                  specification[BRACKET_SHORTCUTS_SHOW_SEGMENTATION_KEY],
+              annotationSelectionDisplaysSegmentationInitialValue:
+                  specification[ANNOTATION_SELECTION_SHOWS_SEGMENTATION_KEY]
+            });
             this.isReady = true;
           });
     }
@@ -245,6 +259,10 @@ export class AnnotationUserLayer extends Base {
     }
     x[LINKED_SEGMENTATION_LAYER_JSON_KEY] = this.linkedSegmentationLayer.toJSON();
     x[FILTER_BY_SEGMENTATION_JSON_KEY] = this.filterBySegmentation.toJSON();
+    x[BRACKET_SHORTCUTS_SHOW_SEGMENTATION_KEY] =
+        this.annotationLayerState.value!.annotationJumpingDisplaysSegmentation.value;
+    x[ANNOTATION_SELECTION_SHOWS_SEGMENTATION_KEY] =
+        this.annotationLayerState.value!.annotationSelectionDisplaysSegmentation.value;
     return x;
   }
 


### PR DESCRIPTION
This PR addresses issues #425 and #432 by adding a checkbox to annotation layers that, when checked, will display any associated segments of an annotation when that annotation is selected. It also saves this new checkbox and the "bracket shortcuts show segmentation" checkboxes in the state as requested.