### PR TITLE
Feat: Supporting authenticated em layer identified by graphene

### DIFF
--- a/src/neuroglancer/authentication/auth_redirect.html
+++ b/src/neuroglancer/authentication/auth_redirect.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    const token = new URLSearchParams(window.location.search).get('token');
+    const token = new URLSearchParams(window.location.search).get('middle_auth_token');
 
     if (token && window.opener) {
         window.opener.postMessage({token: token}, location.origin);

--- a/src/neuroglancer/authentication/backend.ts
+++ b/src/neuroglancer/authentication/backend.ts
@@ -51,8 +51,7 @@ async function reauthenticate(
     waitingForToken = null;
   });
 
-  // returns a promise though I don't use this value since it also gets sent through the
-  // authTokenSharedValue maybe it should be changed to a regular invoke
+  // TODO: change back to promise, we need to handle the promise rejecting even though we get the value from the shared value
   rpc.invoke(
       AUTHENTICATION_REAUTHENTICATE_RPC_ID,
       {auth_url: auth_url, used_token: authTokenSharedValue.value});

--- a/src/neuroglancer/authentication/backend.ts
+++ b/src/neuroglancer/authentication/backend.ts
@@ -17,8 +17,8 @@
 import {AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID, AUTHENTICATION_REAUTHENTICATE_RPC_ID, authFetchWithSharedValue} from 'neuroglancer/authentication/base.ts';
 import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value.ts';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {ResponseTransform} from 'neuroglancer/util/http_request';
 import {rpc} from 'neuroglancer/worker_rpc_context.ts';
-import { ResponseTransform } from 'neuroglancer/util/http_request';
 
 const authTokenSharedValuePromise: Promise<SharedWatchableValue<string|null>> = new Promise((f) => {
   rpc.promiseInvoke<number>(AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID, {}).then((rpcId) => {
@@ -51,7 +51,8 @@ async function reauthenticate(
     waitingForToken = null;
   });
 
-  // TODO: change back to promise, we need to handle the promise rejecting even though we get the value from the shared value
+  // TODO: change back to promise, we need to handle the promise rejecting even though we get the
+  // value from the shared value
   rpc.invoke(
       AUTHENTICATION_REAUTHENTICATE_RPC_ID,
       {auth_url: auth_url, used_token: authTokenSharedValue.value});
@@ -59,8 +60,7 @@ async function reauthenticate(
   return waitingForToken;
 }
 
-export async function authFetch(
-    input: RequestInfo, init?: RequestInit): Promise<Response>;
+export async function authFetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 export async function authFetch<T>(
     input: RequestInfo, init: RequestInit, transformResponse: ResponseTransform<T>,
     cancellationToken: CancellationToken): Promise<T>;
@@ -68,7 +68,8 @@ export async function authFetch<T>(
     input: RequestInfo, init: RequestInit = {}, transformResponse?: ResponseTransform<T>,
     cancellationToken: CancellationToken = uncancelableToken): Promise<T|Response> {
   const authTokenShared = await authTokenSharedValuePromise;
-  const response = await authFetchWithSharedValue(reauthenticate, authTokenShared!, input, init, cancellationToken);
+  const response = await authFetchWithSharedValue(
+      reauthenticate, authTokenShared!, input, init, cancellationToken);
 
   if (transformResponse) {
     return transformResponse(response);

--- a/src/neuroglancer/authentication/base.ts
+++ b/src/neuroglancer/authentication/base.ts
@@ -16,6 +16,7 @@
 
 import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import { HttpError } from 'neuroglancer/util/http_request';
 
 export const AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID = 'Authentication.get_shared_token';
 export const AUTHENTICATION_REAUTHENTICATE_RPC_ID = 'Authentication.reauthenticate';
@@ -36,62 +37,97 @@ export type SharedAuthToken = SharedWatchableValue<string|null>;
 
 type ReauthFunction = (auth_url: string, used_token?: string|SharedAuthToken) => Promise<string>;
 
-export async function authFetchWithSharedValue(
-    reauthenticate: ReauthFunction, authTokenShared: SharedAuthToken, input: RequestInfo, init = {},
-    cancelToken: CancellationToken = uncancelableToken, retry = 1): Promise<Response> {
-  if (!input) {
-    return fetch(input);  // to keep the errors consistent
+export class AuthenticationError extends Error {
+  realm: string;
+
+  constructor(realm: string) {
+    super();
+    this.realm = realm;
   }
+}
 
-  let options = JSON.parse(JSON.stringify(init));
-
-  // handle aborting
-  const abortController = new AbortController();
-  options.signal = abortController.signal;
-  const abort = () => {
-    abortController.abort();
-  };
-  cancelToken.add(abort);
-
-  const authToken = authTokenShared!.value;
-
-  if (authToken) {
-    options.headers = options.headers || new Headers();
-
-    // Headers object seems to be the correct format but a regular object is supported as well
-    if (options.headers instanceof Headers) {
-      options.headers.append('Authorization', `Bearer ${authToken}`);
-    } else {
-      options.headers['Authorization'] = `Bearer ${authToken}`;
-    }
-  }
-
-  return fetch(input, options).then((res) => {
-    cancelToken.remove(abort);
+async function authFetchOk(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  try {
+    const res = await fetch(input, init);
 
     if (res.status === 400 || res.status === 401) {
       const wwwAuth = res.headers.get('WWW-Authenticate');
-
       if (wwwAuth) {
         if (wwwAuth.startsWith('Bearer ')) {
           const wwwAuthMap = parseWWWAuthHeader(wwwAuth);
 
           if (!wwwAuthMap.get('error') || wwwAuthMap.get('error') === 'invalid_token') {
             // missing or expired
-            if (retry > 0) {
-              return reauthenticate(<string>wwwAuthMap.get('realm'), authTokenShared).then(() => {
-                return authFetchWithSharedValue(
-                    reauthenticate, authTokenShared, input, init, cancelToken, retry - 1);
-              });
-            }
+            throw new AuthenticationError(<string>wwwAuthMap.get('realm'));
           }
-
           throw new Error(`status ${res.status} auth error - ${
-              wwwAuthMap.get('error')} + " Reason: ${wwwAuthMap.get('error_description')}`);
+            wwwAuthMap.get('error')} + " Reason: ${wwwAuthMap.get('error_description')}`);
         }
       }
     }
 
+    if (!res.ok) {
+      throw HttpError.fromResponse(res);
+    }
+
     return res;
-  });
+  } catch (error) {
+    // A fetch() promise will reject with a TypeError when a network error is encountered or CORS is misconfigured on the server-side
+    if (error instanceof TypeError) {
+      throw new HttpError('', 0, '');
+    }
+    throw error;
+  }
+}
+
+export async function authFetchWithSharedValue(
+    reauthenticate: ReauthFunction, authTokenShared: SharedAuthToken,
+    input: RequestInfo, init: RequestInit,
+    cancellationToken: CancellationToken = uncancelableToken): Promise<Response> {
+  
+  const aborts: (() => void)[] = [];
+  function addCancellationToken(options: any) {
+    options = JSON.parse(JSON.stringify(init));
+
+    // handle aborting
+    const abortController = new AbortController();
+    options.signal = abortController.signal;
+    const abort = () => {
+      abortController.abort();
+    };
+    cancellationToken.add(abort);
+    aborts.push(abort);
+    return options;
+  }
+
+  function setAuthQuery(input: RequestInfo) {
+    if (input instanceof Request) {
+      // do nothing TODO: is this right?
+    } else {
+      const authToken = authTokenShared!.value;
+
+      if (authToken) {
+        const url = new URL(input);
+        url.searchParams.set('middle_auth_token', authToken);
+        return url.href;
+      }
+    }
+    
+    return input;
+  }
+  
+  try {
+    return await authFetchOk(setAuthQuery(input), addCancellationToken(init));
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      await reauthenticate(error.realm, authTokenShared); // try once after authenticating
+      return await authFetchOk(setAuthQuery(input), addCancellationToken(init));
+    } else {
+      throw error;
+    }
+  } finally {
+    for (let abort of aborts) {
+      cancellationToken.remove(abort);
+    }
+  }
 }

--- a/src/neuroglancer/authentication/base.ts
+++ b/src/neuroglancer/authentication/base.ts
@@ -16,7 +16,7 @@
 
 import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
-import { HttpError } from 'neuroglancer/util/http_request';
+import {HttpError} from 'neuroglancer/util/http_request';
 
 export const AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID = 'Authentication.get_shared_token';
 export const AUTHENTICATION_REAUTHENTICATE_RPC_ID = 'Authentication.reauthenticate';
@@ -61,7 +61,7 @@ async function authFetchOk(input: RequestInfo, init?: RequestInit): Promise<Resp
             throw new AuthenticationError(<string>wwwAuthMap.get('realm'));
           }
           throw new Error(`status ${res.status} auth error - ${
-            wwwAuthMap.get('error')} + " Reason: ${wwwAuthMap.get('error_description')}`);
+              wwwAuthMap.get('error')} + " Reason: ${wwwAuthMap.get('error_description')}`);
         }
       }
     }
@@ -72,7 +72,8 @@ async function authFetchOk(input: RequestInfo, init?: RequestInit): Promise<Resp
 
     return res;
   } catch (error) {
-    // A fetch() promise will reject with a TypeError when a network error is encountered or CORS is misconfigured on the server-side
+    // A fetch() promise will reject with a TypeError when a network error is encountered or CORS is
+    // misconfigured on the server-side
     if (error instanceof TypeError) {
       throw new HttpError('', 0, '');
     }
@@ -81,10 +82,9 @@ async function authFetchOk(input: RequestInfo, init?: RequestInit): Promise<Resp
 }
 
 export async function authFetchWithSharedValue(
-    reauthenticate: ReauthFunction, authTokenShared: SharedAuthToken,
-    input: RequestInfo, init: RequestInit,
+    reauthenticate: ReauthFunction, authTokenShared: SharedAuthToken, input: RequestInfo,
+    init: RequestInit,
     cancellationToken: CancellationToken = uncancelableToken): Promise<Response> {
-  
   const aborts: (() => void)[] = [];
   function addCancellationToken(options: any) {
     options = JSON.parse(JSON.stringify(init));
@@ -112,15 +112,15 @@ export async function authFetchWithSharedValue(
         return url.href;
       }
     }
-    
+
     return input;
   }
-  
+
   try {
     return await authFetchOk(setAuthQuery(input), addCancellationToken(init));
   } catch (error) {
     if (error instanceof AuthenticationError) {
-      await reauthenticate(error.realm, authTokenShared); // try once after authenticating
+      await reauthenticate(error.realm, authTokenShared);  // try once after authenticating
       return await authFetchOk(setAuthQuery(input), addCancellationToken(init));
     } else {
       throw error;

--- a/src/neuroglancer/authentication/frontend.ts
+++ b/src/neuroglancer/authentication/frontend.ts
@@ -18,7 +18,7 @@ import {AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID, AUTHENTICATION_REAUTHENTICATE_RP
 import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value.ts';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
 import {registerPromiseRPC, registerRPC, RPC} from 'neuroglancer/worker_rpc';
-import { ResponseTransform } from '../util/http_request';
+import { ResponseTransform } from 'neuroglancer/util/http_request';
 
 // generate a token with the neuroglancer-auth service using google oauth2
 async function authorize(auth_url: string) {
@@ -32,6 +32,7 @@ async function authorize(auth_url: string) {
   return new Promise<string>((f, r) => {
     const checkClosed = setInterval(() => {
       if (auth_popup.closed) {
+        // in successful case, this will still fire but fulfill will have already been called
         clearInterval(checkClosed);
         r(new Error('Auth popup closed'));
       }

--- a/src/neuroglancer/authentication/frontend.ts
+++ b/src/neuroglancer/authentication/frontend.ts
@@ -17,12 +17,13 @@
 import {AUTHENTICATION_GET_SHARED_TOKEN_RPC_ID, AUTHENTICATION_REAUTHENTICATE_RPC_ID, authFetchWithSharedValue, SharedAuthToken} from 'neuroglancer/authentication/base.ts';
 import {SharedWatchableValue} from 'neuroglancer/shared_watchable_value.ts';
 import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
+import {ResponseTransform} from 'neuroglancer/util/http_request';
 import {registerPromiseRPC, registerRPC, RPC} from 'neuroglancer/worker_rpc';
-import { ResponseTransform } from 'neuroglancer/util/http_request';
 
 // generate a token with the neuroglancer-auth service using google oauth2
 async function authorize(auth_url: string) {
-  const auth_popup = window.open(`${auth_url}?redirect=${encodeURI(window.location.origin + '/auth_redirect.html')}`);
+  const auth_popup = window.open(
+      `${auth_url}?redirect=${encodeURI(window.location.origin + '/auth_redirect.html')}`);
 
   if (!auth_popup) {
     alert('Allow popups on this page to authenticate');
@@ -70,8 +71,7 @@ async function reauthenticate(
   const storedAuthURL = localStorage.getItem('auth_url');
 
   // if the stored token is not what was tried, and auth url matches, try the stored token
-  if (storedToken && storedAuthURL
-      && storedAuthURL === auth_url && storedToken !== used_token) {
+  if (storedToken && storedAuthURL && storedAuthURL === auth_url && storedToken !== used_token) {
     authTokenShared!.value = storedToken;
     return storedToken;
   } else {
@@ -106,15 +106,15 @@ registerRPC(AUTHENTICATION_REAUTHENTICATE_RPC_ID, function({auth_url, used_token
   });
 });
 
-export async function authFetch(
-    input: RequestInfo, init?: RequestInit): Promise<Response>;
+export async function authFetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 export async function authFetch<T>(
     input: RequestInfo, init: RequestInit, transformResponse: ResponseTransform<T>,
     cancellationToken: CancellationToken): Promise<T>;
 export async function authFetch<T>(
     input: RequestInfo, init: RequestInit = {}, transformResponse?: ResponseTransform<T>,
     cancellationToken: CancellationToken = uncancelableToken): Promise<T|Response> {
-  const response = await authFetchWithSharedValue(reauthenticate, authTokenShared!, input, init, cancellationToken);
+  const response = await authFetchWithSharedValue(
+      reauthenticate, authTokenShared!, input, init, cancellationToken);
 
   if (transformResponse) {
     return transformResponse(response);

--- a/src/neuroglancer/authentication/frontend.ts
+++ b/src/neuroglancer/authentication/frontend.ts
@@ -84,10 +84,11 @@ async function reauthenticate(
   }
 }
 
-let authTokenShared: SharedAuthToken|undefined;
+export let authTokenShared: SharedAuthToken|undefined;
 
 export function initAuthTokenSharedValue(rpc: RPC) {
   authTokenShared = SharedWatchableValue.make(rpc, localStorage.getItem('auth_token'));
+  return authTokenShared;
 }
 
 // allow backend thread to access the shared token rpc id so that it can initialize the shared value

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -16,6 +16,7 @@
 
 import {decodeGzip} from 'neuroglancer/async_computation/decode_gzip_request';
 import {requestAsyncComputation} from 'neuroglancer/async_computation/request';
+import {authFetch as cancellableFetchOk} from 'neuroglancer/authentication/backend';
 import {Chunk, ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {GenericSharedDataSource} from 'neuroglancer/chunk_manager/generic_file_source';
 import {ChunkedGraphSourceParameters, DataEncoding, MeshSourceParameters, ShardingHashFunction, ShardingParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/graphene/base';
@@ -33,7 +34,6 @@ import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {Borrowed} from 'neuroglancer/util/disposable';
 import {convertEndian32, Endianness} from 'neuroglancer/util/endian';
 import {murmurHash3_x86_128Hash64Bits} from 'neuroglancer/util/hash';
-import {authFetch as cancellableFetchOk} from 'neuroglancer/authentication/backend';
 import {responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {stableStringify} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
@@ -82,8 +82,8 @@ function getMinishardIndexDataSource(
               const temp = new Uint64();
               Uint64.rshift(temp, shardAndMinishard, sharding.minishardBits);
               Uint64.and(shard, shard, temp);
-              const shardUrl =
-                  `${url}/${shard.toString(16).padStart(Math.ceil(sharding.shardBits / 4), '0')}.shard`;
+              const shardUrl = `${url}/${
+                  shard.toString(16).padStart(Math.ceil(sharding.shardBits / 4), '0')}.shard`;
               // Retrive minishard index start/end offsets.
 
               const shardIndexSize = new Uint64(16);
@@ -264,8 +264,8 @@ export function decodeChunkedGraphChunk(
     for (const [key, val] of chunk.mappings!.entries()) {
       if (val === null) {
         promise = cancellableFetchOk(
-            `${parameters.url}/${key}/leaves?int64_as_str=1&bounds=${bounds}`, {},
-            responseIdentity, cancellationToken);
+            `${parameters.url}/${key}/leaves?int64_as_str=1&bounds=${bounds}`, {}, responseIdentity,
+            cancellationToken);
         promises.push(this.withErrorMessage(
                               promise, `Fetching leaves of segment ${key} in region ${bounds}: `)
                           .then(res => decodeChunkedGraphChunk(chunk, key, res))

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -16,7 +16,6 @@
 
 import {decodeGzip} from 'neuroglancer/async_computation/decode_gzip_request';
 import {requestAsyncComputation} from 'neuroglancer/async_computation/request';
-import {authFetch} from 'neuroglancer/authentication/backend.ts';
 import {Chunk, ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {GenericSharedDataSource} from 'neuroglancer/chunk_manager/generic_file_source';
 import {ChunkedGraphSourceParameters, DataEncoding, MeshSourceParameters, ShardingHashFunction, ShardingParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/graphene/base';
@@ -34,7 +33,8 @@ import {CancellationToken} from 'neuroglancer/util/cancellation';
 import {Borrowed} from 'neuroglancer/util/disposable';
 import {convertEndian32, Endianness} from 'neuroglancer/util/endian';
 import {murmurHash3_x86_128Hash64Bits} from 'neuroglancer/util/hash';
-import {cancellableFetchOk, responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
+import {authFetch as cancellableFetchOk} from 'neuroglancer/authentication/backend';
+import {responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {stableStringify} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {registerSharedObject} from 'neuroglancer/worker_rpc';
@@ -258,11 +258,14 @@ export function decodeChunkedGraphChunk(
 
     let promises = Array<Promise<any>>();
     let promise: Promise<any>;
+
+    const responseIdentity = async (x: any) => x;
+
     for (const [key, val] of chunk.mappings!.entries()) {
       if (val === null) {
-        promise = authFetch(
+        promise = cancellableFetchOk(
             `${parameters.url}/${key}/leaves?int64_as_str=1&bounds=${bounds}`, {},
-            cancellationToken);
+            responseIdentity, cancellationToken);
         promises.push(this.withErrorMessage(
                               promise, `Fetching leaves of segment ${key} in region ${bounds}: `)
                           .then(res => decodeChunkedGraphChunk(chunk, key, res))
@@ -311,10 +314,9 @@ export function decodeDracoFragmentChunk(
 (WithParameters(MeshSource, MeshSourceParameters)) {
   download(chunk: ManifestChunk, cancellationToken: CancellationToken) {
     const {parameters} = this;
-    return authFetch(
+    return cancellableFetchOk(
                `${parameters.manifestUrl}/manifest/${chunk.objectId}:${parameters.lod}?verify=True`,
-               {}, cancellationToken)
-        .then(responseJson)
+               {}, responseJson, cancellationToken)
         .then(response => decodeManifestChunk(chunk, response));
   }
 

--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -218,14 +218,22 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
     if (t !== undefined && t !== 'neuroglancer_multiscale_volume') {
       throw new Error(`Invalid type: ${JSON.stringify(t)}`);
     }
-    this.app = verifyObjectProperty(obj, 'app', x => new AppInfo(infoUrl, x));
-    this.dataUrl = verifyObjectProperty(obj, 'data_dir', x => parseSpecialUrl(x));
+
+    this.volumeType = verifyObjectProperty(obj, 'type', x => verifyEnumString(x, VolumeType));
     this.dataType = verifyObjectProperty(obj, 'data_type', x => verifyEnumString(x, DataType));
+
+    if (this.volumeType === VolumeType.IMAGE) {
+      this.dataUrl = infoUrl;
+    } else {
+      this.app = verifyObjectProperty(obj, 'app', x => new AppInfo(infoUrl, x));
+      this.dataUrl = verifyObjectProperty(obj, 'data_dir', x => parseSpecialUrl(x));
+      this.volumeType = VolumeType.SEGMENTATION_WITH_GRAPH;
+      this.graph = verifyObjectProperty(obj, 'graph', x => new GraphInfo(x));
+    }
+    
     this.numChannels = verifyObjectProperty(obj, 'num_channels', verifyPositiveInt);
-    this.volumeType = VolumeType.SEGMENTATION_WITH_GRAPH;
     this.mesh = verifyObjectProperty(obj, 'mesh', verifyOptionalString);
     this.skeletons = verifyObjectProperty(obj, 'skeletons', verifyOptionalString);
-    this.graph = verifyObjectProperty(obj, 'graph', x => new GraphInfo(x));
     this.scales = verifyObjectProperty(obj, 'scales', x => parseArray(x, y => new ScaleInfo(y)));
   }
 

--- a/src/neuroglancer/datasource/graphene/frontend.ts
+++ b/src/neuroglancer/datasource/graphene/frontend.ts
@@ -230,7 +230,7 @@ export class MultiscaleVolumeChunkSource implements GenericMultiscaleVolumeChunk
       this.volumeType = VolumeType.SEGMENTATION_WITH_GRAPH;
       this.graph = verifyObjectProperty(obj, 'graph', x => new GraphInfo(x));
     }
-    
+
     this.numChannels = verifyObjectProperty(obj, 'num_channels', verifyPositiveInt);
     this.mesh = verifyObjectProperty(obj, 'mesh', verifyOptionalString);
     this.skeletons = verifyObjectProperty(obj, 'skeletons', verifyOptionalString);
@@ -296,8 +296,7 @@ function parseMeshMetadata(data: any): MultiscaleMeshMetadata|undefined {
   const t = verifyObjectProperty(data, '@type', verifyString);
   if (t === 'neuroglancer_legacy_mesh') {
     return undefined;
-  }
-  else if (t !== 'neuroglancer_multilod_draco') {
+  } else if (t !== 'neuroglancer_multilod_draco') {
     throw new Error(`Unsupported mesh type: ${JSON.stringify(t)}`);
   }
   const lodScaleMultiplier =


### PR DESCRIPTION
Example layer:
`graphene://https://minniev1.microns-daf.com/proxy/fly_em`

Also switched from using token in header to token in query param to avoid having to send an options request though this does mean that tokens are likely to leak in server access logs.