### PR TITLE
better storage management, manual storage control

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
       }
     }
   </script>
+  <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet'>
 </head>
 
 <body>

--- a/src/neuroglancer/preferences/user_preferences.ts
+++ b/src/neuroglancer/preferences/user_preferences.ts
@@ -112,5 +112,19 @@ export class UserPreferencesDialog extends Overlay {
     addCheckbox(
         'Unshared state warning', userPreferences.unshareWarning, undefined,
         'Disable the warning message when loading an unshared state.');
+
+    const evictButton = document.createElement('button');
+    evictButton.innerText = '⚠️ Clear Storage';
+    evictButton.title = 'Remove all local storage entries.';
+    evictButton.addEventListener('click', () => {
+      if (confirm(
+              'All unshared or unopened states will be lost and you will need to reauthenticate. The page will be reloaded. Continue?')) {
+        if (viewer.saver) {
+          viewer.saver.userRemoveEntries(true);
+          location.reload();
+        }
+      }
+    });
+    scroll.appendChild(evictButton);
   }
 }

--- a/src/neuroglancer/preferences/user_preferences.ts
+++ b/src/neuroglancer/preferences/user_preferences.ts
@@ -113,18 +113,19 @@ export class UserPreferencesDialog extends Overlay {
         'Unshared state warning', userPreferences.unshareWarning, undefined,
         'Disable the warning message when loading an unshared state.');
 
+    /* TODO: This button may be renabled in the future
     const evictButton = document.createElement('button');
     evictButton.innerText = '⚠️ Clear Storage';
     evictButton.title = 'Remove all local storage entries.';
     evictButton.addEventListener('click', () => {
       if (confirm(
-              'All unshared or unopened states will be lost and you will need to reauthenticate. The page will be reloaded. Continue?')) {
-        if (viewer.saver) {
-          viewer.saver.userRemoveEntries(true);
+              'All unshared or unopened states will be lost and you will need to reauthenticate. The
+    page will be reloaded. Continue?')) { if (viewer.saver) { viewer.saver.userRemoveEntries(true);
           location.reload();
         }
       }
     });
     scroll.appendChild(evictButton);
+    */
   }
 }

--- a/src/neuroglancer/save_state/save_state.css
+++ b/src/neuroglancer/save_state/save_state.css
@@ -32,62 +32,89 @@ button.ng-saver {
 }
 /* Popup container */
 .ng-popup {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-  }
-  
-  /* The actual popup (appears on top) */
-  .ng-popup .ng-popuptext {
-    visibility: hidden;
-    width: 160px;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 8px 0;
-    position: absolute;
-    z-index: 1;
-    bottom: 125%;
-    left: 50%;
-    margin-left: -80px;
-  }
-  
-  /* Popup arrow */
-  .ng-popup .ng-popuptext::after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: #555 transparent transparent transparent;
-  }
-  
-  /* Toggle this class when clicking on the popup container (hide and show the popup) */
-  .ng-popup .ng-show {
-    visibility: visible;
-    -webkit-animation: fadeIn 1s;
-    animation: fadeIn 1s
-  }
-  
-  /* Add animation (fade in the popup) */
-  @-webkit-keyframes fadeIn {
-    from {opacity: 0;}
-    to {opacity: 1;}
-  }
-  
-  @keyframes fadeIn {
-    from {opacity: 0;}
-    to {opacity:1 ;}
-  }
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
 
-  .ng-zebra-table td, .ng-zebra-table th {
-    border: 1px solid #ddd;
-    padding: 8px;
-  }
-  
-  .ng-zebra-table tr:nth-child(even){background-color: #f2f2f2;}
-  
-  .ng-zebra-table tr:hover {background-color: #ddd;}
+/* The actual popup (appears on top) */
+.ng-popup .ng-popuptext {
+  visibility: hidden;
+  width: 160px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 8px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -80px;
+}
+
+/* Popup arrow */
+.ng-popup .ng-popuptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+/* Toggle this class when clicking on the popup container (hide and show the popup) */
+.ng-popup .ng-show {
+  visibility: visible;
+  -webkit-animation: fadeIn 1s;
+  animation: fadeIn 1s
+}
+
+/* Add animation (fade in the popup) */
+@-webkit-keyframes fadeIn {
+  from {opacity: 0;}
+  to {opacity: 1;}
+}
+
+@keyframes fadeIn {
+  from {opacity: 0;}
+  to {opacity:1 ;}
+}
+
+.ng-zebra-table td, .ng-zebra-table th {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+.ng-zebra-table tr:nth-child(even){background-color: #f2f2f2;}
+
+.ng-zebra-table tr:hover {background-color: #ddd;}
+
+.ng-hidden {display: none;}
+
+.ng-dark, .ng-dark button, .ng-dark input{
+  font-family : Roboto;
+  color: #EEEEEE;
+  background-color: #222222;
+}
+
+.ng-dark div {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.ng-dark button.copy_button {
+  background : -moz-linear-gradient(17.04% -35.28% -45deg,rgba(15, 177, 139, 1) 0%,rgba(11, 167, 151, 1) 23.12%,rgba(4, 151, 168, 1) 67.21%,rgba(2, 146, 174, 1) 100%);
+  background : -webkit-linear-gradient(-45deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
+  background : -webkit-gradient(linear,17.04% -35.28% ,82.96% 135.28% ,color-stop(0,rgba(15, 177, 139, 1) ),color-stop(0.2312,rgba(11, 167, 151, 1) ),color-stop(0.6721,rgba(4, 151, 168, 1) ),color-stop(1,rgba(2, 146, 174, 1) ));
+  background : -o-linear-gradient(-45deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
+  background : -ms-linear-gradient(-45deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B', endColorstr='#0292AE' ,GradientType=0)";
+  background : linear-gradient(135deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
+  border-radius : 12px;
+  -moz-border-radius : 12px;
+  -webkit-border-radius : 12px;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B',endColorstr='#0292AE' , GradientType=1);
+}

--- a/src/neuroglancer/save_state/save_state.css
+++ b/src/neuroglancer/save_state/save_state.css
@@ -111,7 +111,7 @@ button.ng-saver {
 }
 
 input.rounded-input {
-  padding: 5px;
+  padding: 8px;
   padding-right: 19px;
   border-radius: 8px;
   border-width: 1px;
@@ -146,10 +146,10 @@ input.rounded-input.disabled {
   -moz-border-radius : 12px;
   -webkit-border-radius : 12px;
   margin-left: 49px;
-  max-height: 35px;
+  max-height: 34px;
   border-radius: 8px;
   font-size: 16px;
-  padding: 7px 17px;
+  padding: 8px 17px;
   align-content: center;
 }
 

--- a/src/neuroglancer/save_state/save_state.css
+++ b/src/neuroglancer/save_state/save_state.css
@@ -100,9 +100,24 @@ button.ng-saver {
   background-color: #222222;
 }
 
+.ng-dark {
+  border-radius: 8px;
+  padding: 46px;
+}
+
 .ng-dark div {
   margin-top: 5px;
   margin-bottom: 5px;
+}
+
+input.rounded-input {
+  padding: 5px;
+  padding-right: 19px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-color: #eeeeee;
+  max-width: 200px;
+  max-height: 22px;
 }
 
 .ng-dark button.copy_button {
@@ -117,4 +132,19 @@ button.ng-saver {
   -moz-border-radius : 12px;
   -webkit-border-radius : 12px;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B',endColorstr='#0292AE' , GradientType=1);
+  margin-left: 49px;
+  max-height: 35px;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  padding: 7px 17px;
+  align-content: center;
+}
+
+.special-button {
+  border: none;
+  font-style: italic;
+  padding: 1px 1px;
+  font-size: 14px;
+  font-weight: bolder;
 }

--- a/src/neuroglancer/save_state/save_state.css
+++ b/src/neuroglancer/save_state/save_state.css
@@ -50,7 +50,7 @@ button.ng-saver {
   z-index: 1;
   bottom: 125%;
   left: 50%;
-  margin-left: -80px;
+  margin-left: 80px;
 }
 
 /* Popup arrow */
@@ -120,6 +120,10 @@ input.rounded-input {
   max-height: 22px;
 }
 
+input.rounded-input.disabled {
+  color: #888888
+}
+
 .ng-dark button.copy_button {
   background : -moz-linear-gradient(17.04% -35.28% -45deg,rgba(15, 177, 139, 1) 0%,rgba(11, 167, 151, 1) 23.12%,rgba(4, 151, 168, 1) 67.21%,rgba(2, 146, 174, 1) 100%);
   background : -webkit-linear-gradient(-45deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
@@ -128,20 +132,32 @@ input.rounded-input {
   background : -ms-linear-gradient(-45deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
   -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B', endColorstr='#0292AE' ,GradientType=0)";
   background : linear-gradient(135deg, rgba(15, 177, 139, 1) 0%, rgba(11, 167, 151, 1) 23.12%, rgba(4, 151, 168, 1) 67.21%, rgba(2, 146, 174, 1) 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B',endColorstr='#0292AE' , GradientType=1);
+  border: none;
+}
+
+.ng-dark button.copy_button.disabled {
+  background: #888888;
+  color: #222222;
+}
+
+.ng-dark button.copy_button, .ng-dark button.shorten_button {
   border-radius : 12px;
   -moz-border-radius : 12px;
   -webkit-border-radius : 12px;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0FB18B',endColorstr='#0292AE' , GradientType=1);
   margin-left: 49px;
   max-height: 35px;
-  border: none;
   border-radius: 8px;
   font-size: 16px;
   padding: 7px 17px;
   align-content: center;
 }
 
-.special-button {
+.ng-dark button.shorten_button {
+  border-color: #eeeeee;
+}
+
+button.special-button {
   border: none;
   font-style: italic;
   padding: 1px 1px;

--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -301,10 +301,16 @@ class SaveDialog extends Overlay {
 
     const viewSimple = document.createElement('div');
     {
-      // viewSimple.append(this.makePopup('JSON_URL'));
+      viewSimple.append(this.makePopup('JSON_URL'));
       this.insertField(
           viewSimple, 'JSON_URL', jsonUrl, 'neuroglancer-save-state-json',
           jsonUrl === 'NOT AVAILABLE', 'Copy', 'CTRL + SHIFT + J', undefined, 'copy_button');
+      viewSimple.append(br());
+      viewSimple.append(this.makePopup('RAW_URL'));
+      this.insertLabel(viewSimple, 'Long Link', 'neuroglancer-save-state-raw');
+      this.insertField(
+          viewSimple, 'RAW_URL', rawUrl, 'neuroglancer-save-state-raw', false, 'Copy',
+          'CTRL + SHIFT + R', undefined, 'copy_button');
     }
 
     const advanceTab = document.createElement('button');
@@ -316,12 +322,14 @@ class SaveDialog extends Overlay {
     });
     {
       viewAdvanc.classList.add('ng-hidden');
-      // viewAdvanc.append(this.makePopup('RAW_URL'));
+      /*
+      viewAdvanc.append(this.makePopup('RAW_URL'));
       // viewAdvanc.append(br());
-      this.insertLabel(viewAdvanc, 'Raw Link', 'neuroglancer-save-state-raw');
+      this.insertLabel(viewAdvanc, 'Long Link', 'neuroglancer-save-state-raw');
       this.insertField(
           viewAdvanc, 'RAW_URL', rawUrl, 'neuroglancer-save-state-raw', false, 'Copy',
-          'CTRL + SHIFT + R', undefined, 'copy_button');
+        'CTRL + SHIFT + R', undefined, 'copy_button');
+      */
       viewAdvanc.append(br());
       this.insertLabel(viewAdvanc, 'Link Shortener', 'neuroglancer-save-state-linkshare');
       this.insertField(

--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -46,7 +46,7 @@ export class SaveState extends RefCounted {
     }
   }
   // Main Methods
-  pull() {
+  public pull() {
     // Get SaveEntry from localStorage
     if (storageAccessible() && this.key) {
       const entry = localStorage[`${stateKey}-${this.key}`];
@@ -56,7 +56,7 @@ export class SaveState extends RefCounted {
     }
     return;
   }
-  push(clean?: boolean) {
+  public push(clean?: boolean) {
     // update SaveEntry in localStorage
     if (storageAccessible() && this.key) {
       const source = <SaveEntry>this.pull() || {};
@@ -83,7 +83,7 @@ export class SaveState extends RefCounted {
       this.notifyManager();
     }
   }
-  commit(source_url: string) {
+  public commit(source_url: string) {
     if (this.key) {
       this.savedUrl = source_url;
       this.addToHistory(recordHistory(source_url));
@@ -173,10 +173,10 @@ export class SaveState extends RefCounted {
   overwriteHistory(newHistory: SaveHistory[] = []) {
     this.robustSet(historyKey, JSON.stringify(newHistory));
   }
-  showSaveDialog(viewer: Viewer, jsonString?: string, get?: UrlType) {
+  public showSaveDialog(viewer: Viewer, jsonString?: string, get?: UrlType) {
     new SaveDialog(viewer, jsonString, get);
   }
-  showHistory(viewer: Viewer) {
+  public showHistory(viewer: Viewer) {
     new SaveHistoryDialog(viewer, this);
   }
   // Helper

--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -298,6 +298,8 @@ class SaveDialog extends Overlay {
     title.innerText = 'Share Link';
     const descr = document.createElement('div');
     descr.innerText = 'This link lets you share the exact view you currently see in neuroglancer.';
+    descr.style.paddingBottom = '10px';
+    descr.style.maxWidth = '360px';
 
     const viewSimple = document.createElement('div');
     {
@@ -316,6 +318,7 @@ class SaveDialog extends Overlay {
     const advanceTab = document.createElement('button');
     advanceTab.innerHTML = 'Advanced Options';
     advanceTab.type = 'button';
+    advanceTab.classList.add('special-button');
     const viewAdvanc = document.createElement('div');
     advanceTab.addEventListener('click', () => {
       viewAdvanc.classList.toggle('ng-hidden');
@@ -428,6 +431,7 @@ class SaveDialog extends Overlay {
       text.id = textId;
       btn.id = `${text.id}-button`;
     }
+    text.classList.add('rounded-input');
 
     if (popupID) {
       const copyFtn = () => {

--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -394,6 +394,7 @@ class SaveDialog extends Overlay {
         btnClass: 'shorten_button'
       });
 
+      /* TODO: This button may be renabled in the future
       const clearButton = document.createElement('button');
       {
         clearButton.innerText = '⚠️ Clear States';
@@ -407,6 +408,9 @@ class SaveDialog extends Overlay {
           }
         });
       }
+      viewAdvanc.append(br());
+      viewAdvanc.append(clearButton);
+      */
     }
 
     formMain.append(title, descr, viewSimple, br(), advanceTab, viewAdvanc);

--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -369,6 +369,7 @@ class SaveDialog extends Overlay {
         content: viewer.jsonStateServer.value,
         textId: 'neuroglancer-save-state-linkshare',
         fieldTitle: '',
+        readonly: false,
         btnName: 'Shorten',
         btnTitle: 'Push to state server to get JSON URL.',
         btnAct: () => {


### PR DESCRIPTION
addresses #433 

replaced storageAvailable with storageAccessible, which only returns false if localStorage has been disabled

Share Button is disabled when state server push is made from Share Button or Share Button from Warning Status Message. This matches the behavior of pressing the "Post State to State Server" button.


Adds Clear States and Clear Storage buttons, the former purges all existing states, while the later completely clears local storage entirely and triggers a reload.

Local Storage is tied to domain so this only affects Neuroglancer

Share button should only highlight when the state has actually changed and not been shared

history only keeps most recent 100 entries, after which it starts deleting old ones, additionally save history can trigger LRU eviction if it LocalStorage is full.

LocalStorage has problems when full, as active states may be deleted but they are only lost if the tab/window/page is closed.

Tested full storage using the following: https://stackoverflow.com/a/45760532 pasted right into the console.