### PR TITLE
Fix: Made checking response.ok optional in authFetch so chunked graph operations can correctly handle the errors

### DIFF
--- a/src/neuroglancer/authentication/backend.ts
+++ b/src/neuroglancer/authentication/backend.ts
@@ -60,16 +60,19 @@ async function reauthenticate(
   return waitingForToken;
 }
 
+export const responseIdentity = async (x: any) => x;
+
 export async function authFetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 export async function authFetch<T>(
-    input: RequestInfo, init: RequestInit, transformResponse: ResponseTransform<T>,
-    cancellationToken: CancellationToken): Promise<T>;
+    input: RequestInfo, init: RequestInit, transformResponse: ResponseTransform<T>|undefined,
+    cancellationToken?: CancellationToken, handleError?: boolean): Promise<T>;
 export async function authFetch<T>(
-    input: RequestInfo, init: RequestInit = {}, transformResponse?: ResponseTransform<T>,
-    cancellationToken: CancellationToken = uncancelableToken): Promise<T|Response> {
+    input: RequestInfo, init: RequestInit = {}, transformResponse?: ResponseTransform<T>|undefined,
+    cancellationToken: CancellationToken = uncancelableToken,
+    handleError = true): Promise<T|Response> {
   const authTokenShared = await authTokenSharedValuePromise;
   const response = await authFetchWithSharedValue(
-      reauthenticate, authTokenShared!, input, init, cancellationToken);
+      reauthenticate, authTokenShared!, input, init, cancellationToken, handleError);
 
   if (transformResponse) {
     return transformResponse(response);

--- a/src/neuroglancer/authentication/frontend.ts
+++ b/src/neuroglancer/authentication/frontend.ts
@@ -106,15 +106,18 @@ registerRPC(AUTHENTICATION_REAUTHENTICATE_RPC_ID, function({auth_url, used_token
   });
 });
 
+export const responseIdentity = async (x: any) => x;
+
 export async function authFetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 export async function authFetch<T>(
-    input: RequestInfo, init: RequestInit, transformResponse: ResponseTransform<T>,
-    cancellationToken: CancellationToken): Promise<T>;
+    input: RequestInfo, init: RequestInit, transformResponse?: ResponseTransform<T>,
+    cancellationToken?: CancellationToken, handleError?: boolean): Promise<T>;
 export async function authFetch<T>(
     input: RequestInfo, init: RequestInit = {}, transformResponse?: ResponseTransform<T>,
-    cancellationToken: CancellationToken = uncancelableToken): Promise<T|Response> {
+    cancellationToken: CancellationToken = uncancelableToken,
+    handleError = true): Promise<T|Response> {
   const response = await authFetchWithSharedValue(
-      reauthenticate, authTokenShared!, input, init, cancellationToken);
+      reauthenticate, authTokenShared!, input, init, cancellationToken, handleError);
 
   if (transformResponse) {
     return transformResponse(response);

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -16,7 +16,7 @@
 
 import {decodeGzip} from 'neuroglancer/async_computation/decode_gzip_request';
 import {requestAsyncComputation} from 'neuroglancer/async_computation/request';
-import {authFetch as cancellableFetchOk} from 'neuroglancer/authentication/backend';
+import {authFetch as cancellableFetchOk, responseIdentity} from 'neuroglancer/authentication/backend';
 import {Chunk, ChunkManager, WithParameters} from 'neuroglancer/chunk_manager/backend';
 import {GenericSharedDataSource} from 'neuroglancer/chunk_manager/generic_file_source';
 import {ChunkedGraphSourceParameters, DataEncoding, MeshSourceParameters, ShardingHashFunction, ShardingParameters, SkeletonSourceParameters, VolumeChunkEncoding, VolumeChunkSourceParameters} from 'neuroglancer/datasource/graphene/base';
@@ -259,13 +259,11 @@ export function decodeChunkedGraphChunk(
     let promises = Array<Promise<any>>();
     let promise: Promise<any>;
 
-    const responseIdentity = async (x: any) => x;
-
     for (const [key, val] of chunk.mappings!.entries()) {
       if (val === null) {
         promise = cancellableFetchOk(
             `${parameters.url}/${key}/leaves?int64_as_str=1&bounds=${bounds}`, {}, responseIdentity,
-            cancellationToken);
+            cancellationToken, false);
         promises.push(this.withErrorMessage(
                               promise, `Fetching leaves of segment ${key} in region ${bounds}: `)
                           .then(res => decodeChunkedGraphChunk(chunk, key, res))

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {authFetch} from 'neuroglancer/authentication/frontend.ts';
+import {authFetch, responseIdentity} from 'neuroglancer/authentication/frontend.ts';
 import {ChunkManager} from 'neuroglancer/chunk_manager/frontend';
 import {VisibleSegmentsState} from 'neuroglancer/segmentation_display_state/base';
 import {CHUNKED_GRAPH_LAYER_RPC_ID, CHUNKED_GRAPH_SOURCE_UPDATE_ROOT_SEGMENTS_RPC_ID, ChunkedGraphChunkSource as ChunkedGraphChunkSourceInterface, ChunkedGraphChunkSpecification, RENDER_RATIO_LIMIT} from 'neuroglancer/sliceview/chunked_graph/base';
@@ -113,8 +113,10 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.resolve(selection.segmentId);
     }
 
-    const promise = authFetch(`${url}/node/${String(selection.segmentId)}/root?int64_as_str=1${
-        timestamp ? `&timestamp=${timestamp}` : ``}`);
+    const promise = authFetch(
+        `${url}/node/${String(selection.segmentId)}/root?int64_as_str=1${
+            timestamp ? `&timestamp=${timestamp}` : ``}`,
+        {}, responseIdentity, undefined, false);
 
     const response = await this.withErrorMessage(promise, {
       initialMessage: `Retrieving root for segment ${selection.segmentId}`,
@@ -130,13 +132,15 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/merge?int64_as_str=1`, {
-      method: 'POST',
-      body: JSON.stringify([
-        [String(first.segmentId), ...first.position.values()],
-        [String(second.segmentId), ...second.position.values()]
-      ])
-    });
+    const promise = authFetch(
+        `${url}/merge?int64_as_str=1`, {
+          method: 'POST',
+          body: JSON.stringify([
+            [String(first.segmentId), ...first.position.values()],
+            [String(second.segmentId), ...second.position.values()]
+          ])
+        },
+        responseIdentity, undefined, false);
 
     const response = await this.withErrorMessage(promise, {
       initialMessage: `Merging ${first.segmentId} and ${second.segmentId}`,
@@ -152,13 +156,15 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/split?int64_as_str=1`, {
-      method: 'POST',
-      body: JSON.stringify({
-        'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),
-        'sinks': second.map(x => [String(x.segmentId), ...x.position.values()])
-      })
-    });
+    const promise = authFetch(
+        `${url}/split?int64_as_str=1`, {
+          method: 'POST',
+          body: JSON.stringify({
+            'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),
+            'sinks': second.map(x => [String(x.segmentId), ...x.position.values()])
+          })
+        },
+        responseIdentity, undefined, false);
 
     const response = await this.withErrorMessage(promise, {
       initialMessage: `Splitting ${first.length} sources from ${second.length} sinks`,
@@ -179,13 +185,15 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/graph/split_preview?int64_as_str=1`, {
-      method: 'POST',
-      body: JSON.stringify({
-        'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),
-        'sinks': second.map(x => [String(x.segmentId), ...x.position.values()])
-      })
-    });
+    const promise = authFetch(
+        `${url}/graph/split_preview?int64_as_str=1`, {
+          method: 'POST',
+          body: JSON.stringify({
+            'sources': first.map(x => [String(x.segmentId), ...x.position.values()]),
+            'sinks': second.map(x => [String(x.segmentId), ...x.position.values()])
+          })
+        },
+        responseIdentity, undefined, false);
 
     const response = await this.withErrorMessage(promise, {
       initialMessage:


### PR DESCRIPTION
broken by recent change to make authFetch conform to fetchOk behavior.