### PR TITLE
add precision mode checkbox to find path widget

### DIFF
--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -216,19 +216,22 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     return {supervoxelConnectedComponents, isSplitIllegal: jsonResp[jsonIllegalSplitKey]};
   }
 
-  async findPath(first: SegmentSelection, second: SegmentSelection): Promise<number[][]> {
+  async findPath(first: SegmentSelection, second: SegmentSelection, precisionMode: boolean):
+      Promise<number[][]> {
     const {url} = this;
     if (url === '') {
       return Promise.reject(GRAPH_SERVER_NOT_SPECIFIED);
     }
 
-    const promise = authFetch(`${url}/graph/find_path?int64_as_str=1`, {
-      method: 'POST',
-      body: JSON.stringify([
-        [String(first.segmentId), ...first.position.values()],
-        [String(second.segmentId), ...second.position.values()]
-      ])
-    });
+    // const precisionBit = (precisionMode) ? 1 : 0;
+    const promise =
+        authFetch(`${url}/graph/find_path?int64_as_str=1&precision_mode=${Number(precisionMode)}`, {
+          method: 'POST',
+          body: JSON.stringify([
+            [String(first.segmentId), ...first.position.values()],
+            [String(second.segmentId), ...second.position.values()]
+          ])
+        });
 
     const response = await this.withErrorMessage(promise, {
       initialMessage: `Finding path between ${first.segmentId} and ${second.segmentId}`,

--- a/src/neuroglancer/widget/find_path_widget.css
+++ b/src/neuroglancer/widget/find_path_widget.css
@@ -21,3 +21,9 @@
 #path-finder-color-widget {
   width: 60%;
 }
+
+#precision-mode-checkbox {
+  /* vertical-align: bottom; */
+  position: relative;
+  top: 3px;
+}

--- a/src/neuroglancer/widget/find_path_widget.ts
+++ b/src/neuroglancer/widget/find_path_widget.ts
@@ -37,6 +37,7 @@ const hsv = new Float32Array(3);
 
 export class FindPathWidget extends RefCounted {
   private findPathButton = document.createElement('button');
+  private precisionModeCheckbox = document.createElement('input');
 
   constructor(
       private findPathGroup: Borrowed<MinimizableGroupWidget>,
@@ -69,7 +70,7 @@ export class FindPathWidget extends RefCounted {
       this.layer.tool.value = new PathFindingMarkerTool(this.layer);
     });
     let pathFound = false;
-    const {findPathButton} = this;
+    const {findPathButton, precisionModeCheckbox} = this;
     findPathButton.textContent = '✔️';
     findPathButton.title = 'Find path';
     findPathButton.addEventListener('click', () => {
@@ -87,7 +88,8 @@ export class FindPathWidget extends RefCounted {
           this.layer.chunkedGraphLayer!
               .findPath(
                   getSegmentSelectionFromPoint(this.pathBetweenSupervoxels.source!),
-                  getSegmentSelectionFromPoint(this.pathBetweenSupervoxels.target!))
+                  getSegmentSelectionFromPoint(this.pathBetweenSupervoxels.target!),
+                  precisionModeCheckbox.checked)
               .then((centroids) => {
                 pathFound = true;
                 findPathButton.title = 'Path found!';
@@ -123,6 +125,14 @@ export class FindPathWidget extends RefCounted {
     toolbox.appendChild(findPathButton);
     toolbox.appendChild(clearButton);
     this.findPathGroup.appendFixedChild(toolbox);
+    
+    precisionModeCheckbox.type = 'checkbox';
+    precisionModeCheckbox.id = 'precision-mode-checkbox';
+    const checkboxLabel = document.createElement('label');
+    checkboxLabel.textContent = 'Precision mode: ';
+    checkboxLabel.title = 'Precision mode returns a more accurate path, but takes longer.';
+    checkboxLabel.appendChild(precisionModeCheckbox);
+    this.findPathGroup.appendFlexibleChild(checkboxLabel);
   }
 
   // Rotate color by 60 degrees on color wheel (to match up with annotation line


### PR DESCRIPTION
High precision is default behavior, but mesh downloading takes a long time with new sharded mesh format. Add rough lower precision option that doesn't require mesh download.