### PR TITLE
Fix: Multicut blackout segment 0

### DIFF
--- a/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
+++ b/src/neuroglancer/sliceview/volume/segmentation_renderlayer.ts
@@ -188,14 +188,6 @@ uint64_t getMappedObjectId() {
   float alpha = uSelectedAlpha;
   float saturation = uSaturation;
 `;
-    if (this.displayState.hideSegmentZero.value) {
-      fragmentMain += `
-  if (value.value[0] == 0u && value.value[1] == 0u) {
-    emit(vec4(vec4(0, 0, 0, 0)));
-    return;
-  }
-`;
-    }
     fragmentMain += `
   if (uFocusMulticutSegments == 1u) {
     bool has = uShowAllSegments != 0u ? true : ${
@@ -208,6 +200,14 @@ uint64_t getMappedObjectId() {
     return;
   } else {
 `;
+    if (this.displayState.hideSegmentZero.value) {
+      fragmentMain += `
+  if (value.value[0] == 0u && value.value[1] == 0u) {
+    emit(vec4(vec4(0, 0, 0, 0)));
+    return;
+  }
+`;
+    }
     fragmentMain += `
     bool has = uShowAllSegments != 0u ? true : ${this.hashTableManager.hasFunctionName}(value);
     if (uSelectedSegment == value.value) {


### PR DESCRIPTION
The multicut darkens the segments around that are not the one being cut. However it does not do so for segment 0; this PR fixes this. 

See: #468 