### PR TITLE
Fix size of layer item

### DIFF
--- a/src/neuroglancer/layer_panel.css
+++ b/src/neuroglancer/layer_panel.css
@@ -40,12 +40,6 @@
   padding: 1px;
 }
 
-.neuroglancer-layer-item-value-wrapper {
-  white-space: nowrap;
-  overflow: hidden;
-  width: 4.4vw;
-}
-
 .neuroglancer-layer-item, .neuroglancer-layer-add-button {
   margin: 1px;
   margin-left: 5px;
@@ -92,7 +86,8 @@
 
 .neuroglancer-layer-item-value {
   display: inline-block;
-  min-width: 10ch;
+  font-family: monospace;
+  font-size: medium;
   max-width: 50ch;
   margin-left: 1ch;
   white-space: nowrap;

--- a/src/neuroglancer/layer_panel.css
+++ b/src/neuroglancer/layer_panel.css
@@ -40,6 +40,12 @@
   padding: 1px;
 }
 
+.neuroglancer-layer-item-value-wrapper {
+  white-space: nowrap;
+  overflow: hidden;
+  width: 4.4vw;
+}
+
 .neuroglancer-layer-item, .neuroglancer-layer-add-button {
   margin: 1px;
   margin-left: 5px;

--- a/src/neuroglancer/layer_panel.ts
+++ b/src/neuroglancer/layer_panel.ts
@@ -168,6 +168,8 @@ class LayerWidget extends RefCounted {
   layerNumberElement: HTMLSpanElement;
   labelElement: HTMLSpanElement;
   valueElement: HTMLSpanElement;
+  maxLength: number = 0;
+  prevValueText: string = '';
 
   constructor(public layer: ManagedUserLayerWithSpecification, public panel: LayerPanel) {
     super();
@@ -245,10 +247,7 @@ class LayerWidget extends RefCounted {
     element.appendChild(colorWidget.element);
     element.appendChild(layerNumberElement);
     element.appendChild(labelElement);
-    const valueWrapperElement = document.createElement('span');
-    valueWrapperElement.classList.add('neuroglancer-layer-item-value-wrapper');
-    valueWrapperElement.appendChild(valueElement);
-    element.appendChild(valueWrapperElement);
+    element.appendChild(valueElement);
     if (timeWarningElement) {
       element.appendChild(timeWarningElement);
     }
@@ -441,6 +440,12 @@ export class LayerPanel extends RefCounted {
           });
           text += value.join(', ');
         }
+      }
+      if (text === widget.prevValueText) continue;
+      widget.prevValueText = text;
+      if (text.length > widget.maxLength) {
+        const length = widget.maxLength = text.length;
+        widget.valueElement.style.width = `${length}ch`;
       }
       widget.valueElement.textContent = text;
     }

--- a/src/neuroglancer/layer_panel.ts
+++ b/src/neuroglancer/layer_panel.ts
@@ -245,7 +245,10 @@ class LayerWidget extends RefCounted {
     element.appendChild(colorWidget.element);
     element.appendChild(layerNumberElement);
     element.appendChild(labelElement);
-    element.appendChild(valueElement);
+    const valueWrapperElement = document.createElement('span');
+    valueWrapperElement.classList.add('neuroglancer-layer-item-value-wrapper');
+    valueWrapperElement.appendChild(valueElement);
+    element.appendChild(valueWrapperElement);
     if (timeWarningElement) {
       element.appendChild(timeWarningElement);
     }


### PR DESCRIPTION
Create a span to fix the size of the layer bar item. This fixes the problem of hovering over a segment/supervoxel and having the view change as all the layer items shift over (see: #450). The user can no longer see the full segment ID in the layer bar item however.