### PR TITLE
Fix: fix max height of segment set widget to prevent overflow

### DIFF
--- a/src/neuroglancer/widget/segment_set_widget.css
+++ b/src/neuroglancer/widget/segment_set_widget.css
@@ -32,7 +32,7 @@
 .segment-set-widget .item-container {
   display: flex;
   flex-wrap: wrap;
-  max-height: 50vh;
+  max-height: 40vh;
 }
 
 .copy-all-segment-IDs-button {

--- a/src/neuroglancer/widget/segment_set_widget.css
+++ b/src/neuroglancer/widget/segment_set_widget.css
@@ -32,6 +32,7 @@
 .segment-set-widget .item-container {
   display: flex;
   flex-wrap: wrap;
+  max-height: 50vh;
 }
 
 .copy-all-segment-IDs-button {


### PR DESCRIPTION
Our current minimizable group styling has been broken by the latest Chrome update. Currently, overflow causes the segment set widget to become tiny and hard to use. Workaround: set a max vh for the widget until we fix the group styling.