### PR TITLE
Alert user when no WebGL2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,6 +33,13 @@
         }
       }
     }
+    // WebGL2 support test
+    {
+      const gl = document.createElement('canvas').getContext('webgl2');
+      if (!gl) {
+        alert('Your browser does not support WebGL2, or it is not enabled. Please use a browser that does, such as Chrome or Firefox.');
+      }
+    }
   </script>
   <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet'>
 </head>

--- a/src/neuroglancer/webgl/context.ts
+++ b/src/neuroglancer/webgl/context.ts
@@ -38,8 +38,6 @@ export function initializeWebGL(canvas: HTMLCanvasElement) {
   let gl =
       <GL>canvas.getContext('webgl2', options);
   if (gl == null) {
-    alert(
-        'Your browser does not support WebGL2, or it is not enabled. Please use a browser that does, such as Chrome or Firefox.');
     throw new Error('WebGL not supported.');
   }
   gl.memoize = new Memoize<any, RefCounted>();

--- a/src/neuroglancer/webgl/context.ts
+++ b/src/neuroglancer/webgl/context.ts
@@ -38,6 +38,8 @@ export function initializeWebGL(canvas: HTMLCanvasElement) {
   let gl =
       <GL>canvas.getContext('webgl2', options);
   if (gl == null) {
+    alert(
+        'Your browser does not support WebGL2, or it is not enabled. Please use a browser that does, such as Chrome or Firefox.');
     throw new Error('WebGL not supported.');
   }
   gl.memoize = new Memoize<any, RefCounted>();


### PR DESCRIPTION
A StatusMessage already appears at the bottom when there is no WebGL2 support, but an alert message is much clearer and more explicit. See: #443 