### PR TITLE
shortcut to reload mesh

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,28 +1,6 @@
-### 🌴 July 2019 ☀️
-# New Annotation Controls
-* Shift + Click
-    * Select a continous section of annotations between the previous selection and current selection.
-    * Cannot select annotations of different hierarchy levels i.e annotations inside a collection with those outside that collection.
-    * Will deselect annotations that are already selected.
-* Ctrl + Click
-    * Works the same as before for selecting.
-    * **Will now deselect annotations that are already selected.**
-* Collection Editing
-    * Activate edit mode for an existing Collection via the "📝" button.
-    * Add annotations in edit mode by pressing the "➕" button.
-    * Spoke annotations can be edited. Added annotations will be transformed into points that connect with the center.
-    * LineStrip annotations cannot be edited.
-* Generate Spoke and LineStrip from existing annotations.
-    * Uses existing annotations as positions/points in generated collection.
-    * With multiple annotations selected press "ʌ" for a LineStrip and "⚹" for a spoke.
-    * **This will not delete the originally selected annotations.**
-    * To **delete the source annotations**, uncheck "Preserve Source Annotations" in User Preferences.
-* Generate Point(s) from selected annotation.
-    * Press "⚬" to reduce a given annotation to its component points.
-    * Line and Bounding Box annotations reduce into their endpoints.
-    * All other two-step annotations reduce into their center point.
-    * Collection annotations reduce their child annotations.
-    * Special collections **remove overlapping point annotations**.
-    * **Cannot reduce the children of special collections.**
-* First annotation in a selection is now animated.
-* 🌐 Ellipsoid annotations are fixed. 👀
+### 🌴 August 2020 ☀️
+## Shortcut to reload mesh
+`Ctrl + Shift + LeftClick` on any visible segment in 2D/3D to reload its mesh after an edit.
+This helps avoid having to refresh Neuroglancer to see the new mesh.
+
+NOTE: You may need to do this more than once because Neuroglancer cannot know if the remeshing process has completed.

--- a/src/neuroglancer/datasource/graphene/backend.ts
+++ b/src/neuroglancer/datasource/graphene/backend.ts
@@ -30,14 +30,15 @@ import {decodeRawChunk} from 'neuroglancer/sliceview/backend_chunk_decoders/raw'
 import {ChunkedGraphChunk, ChunkedGraphChunkSource, decodeSupervoxelArray} from 'neuroglancer/sliceview/chunked_graph/backend';
 import {VolumeChunk, VolumeChunkSource} from 'neuroglancer/sliceview/volume/backend';
 import {fetchHttpByteRange} from 'neuroglancer/util/byte_range_http_requests';
-import {CancellationToken} from 'neuroglancer/util/cancellation';
+import {CancellationToken, uncancelableToken} from 'neuroglancer/util/cancellation';
 import {Borrowed} from 'neuroglancer/util/disposable';
 import {convertEndian32, Endianness} from 'neuroglancer/util/endian';
 import {murmurHash3_x86_128Hash64Bits} from 'neuroglancer/util/hash';
 import {responseArrayBuffer, responseJson} from 'neuroglancer/util/http_request';
 import {stableStringify} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
-import {registerSharedObject} from 'neuroglancer/worker_rpc';
+import {registerRPC, registerSharedObject} from 'neuroglancer/worker_rpc';
+import {GRAPHENE_MANIFEST_REFRESH} from 'neuroglancer/datasource/graphene/base';
 
 const DracoLoader = require('dracoloader');
 
@@ -361,3 +362,10 @@ export class GrapheneSkeletonSource extends
     decodeSkeletonChunk(chunk, response, parameters.metadata.vertexAttributes);
   }
 }
+
+registerRPC(GRAPHENE_MANIFEST_REFRESH, function(x) {
+  let obj = <GrapheneMeshSource>this.get(x['id']);
+  let manifestChunk = obj.getChunk(Uint64.parseString(x['segment']));
+  obj.download(manifestChunk, uncancelableToken);
+  manifestChunk.downloadSucceeded();
+});

--- a/src/neuroglancer/datasource/graphene/base.ts
+++ b/src/neuroglancer/datasource/graphene/base.ts
@@ -18,7 +18,7 @@ import {VertexAttributeInfo} from 'neuroglancer/skeleton/base';
 import {mat4} from 'neuroglancer/util/geom';
 
 export const PYCG_APP_VERSION = 1;
-export const GRAPHENE_MANIFEST_REFRESH = 'GrapheneMeshSource.RefreshManifest';
+export const GRAPHENE_MANIFEST_REFRESH_PROMISE = 'GrapheneMeshSource.RefreshManifestPromise';
 
 export enum VolumeChunkEncoding {
   RAW,

--- a/src/neuroglancer/datasource/graphene/base.ts
+++ b/src/neuroglancer/datasource/graphene/base.ts
@@ -18,6 +18,7 @@ import {VertexAttributeInfo} from 'neuroglancer/skeleton/base';
 import {mat4} from 'neuroglancer/util/geom';
 
 export const PYCG_APP_VERSION = 1;
+export const GRAPHENE_MANIFEST_REFRESH = 'GrapheneMeshSource.RefreshManifest';
 
 export enum VolumeChunkEncoding {
   RAW,

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -38,6 +38,7 @@ import {vec3} from 'neuroglancer/util/geom';
 import {parseArray, verifyObjectProperty} from 'neuroglancer/util/json';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {NullarySignal} from './util/signal';
+import {GRAPHENE_MANIFEST_REFRESH} from 'neuroglancer/datasource/graphene/base';
 
 // Already defined in segmentation_user_layer.ts
 const EQUIVALENCES_JSON_KEY = 'equivalences';
@@ -309,6 +310,10 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
               5000);
           break;
         }
+        case 'reload-manifest': {
+          this.reloadManifest();
+          break;
+        }         
         default:
           super.handleAction(action);
           break;
@@ -456,6 +461,20 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
         } else {
           StatusMessage.showTemporaryMessage(
               `Split unsuccessful - graph layer not initialized.`, 3000);
+        }
+      }
+    }
+
+    reloadManifest() {
+      let {segmentSelectionState} = this.displayState;
+      if (segmentSelectionState.hasSelectedSegment) {
+        let segment = segmentSelectionState.selectedSegment;
+        let {rootSegments} = this.displayState;
+        if (rootSegments.has(segment)) {
+          let meshSource = this.meshLayer!.source;
+          meshSource.rpc!.invoke(
+            GRAPHENE_MANIFEST_REFRESH,
+            {'id': meshSource.rpcId, 'segment': segment.toString()});
         }
       }
     }

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -310,7 +310,7 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
               5000);
           break;
         }
-        case 'reload-manifest': {
+        case 'refresh-mesh': {
           this.reloadManifest();
           break;
         }         

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -256,7 +256,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     status.setText(options.initialMessage);
     const dispose = status.dispose.bind(status);
     let response = await promise;
-    if (!(response instanceof Response)) {
+    if (response !== undefined && !(response instanceof Response)) {
       response = new Response(response);
     }
     if (response.ok) {

--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -255,7 +255,10 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     const status = new StatusMessage(true);
     status.setText(options.initialMessage);
     const dispose = status.dispose.bind(status);
-    const response = await promise;
+    let response = await promise;
+    if (!(response instanceof Response)) {
+      response = new Response(response);
+    }
     if (response.ok) {
       dispose();
       return response;

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -93,6 +93,7 @@ export function getDefaultRenderedDataPanelBindings() {
           'at:control+mousedown2': 'select-annotation',
           'at:alt+mousedown0': 'move-annotation',
           'at:control+alt+mousedown2': 'delete-annotation',
+          'at:control+shift+mousedown0': 'reload-manifest',
           'at:touchpinch': 'zoom-via-touchpinch',
           'at:touchrotate': 'rotate-in-plane-via-touchrotate',
           'at:touchtranslate2': 'translate-in-plane-via-touchtranslate',

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -93,7 +93,7 @@ export function getDefaultRenderedDataPanelBindings() {
           'at:control+mousedown2': 'select-annotation',
           'at:alt+mousedown0': 'move-annotation',
           'at:control+alt+mousedown2': 'delete-annotation',
-          'at:control+shift+mousedown0': 'reload-manifest',
+          'at:control+shift+mousedown0': 'refresh-mesh',
           'at:touchpinch': 'zoom-via-touchpinch',
           'at:touchrotate': 'rotate-in-plane-via-touchrotate',
           'at:touchtranslate2': 'translate-in-plane-via-touchtranslate',

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -660,7 +660,7 @@ export class Viewer extends RefCounted implements ViewerState {
       });
     }
 
-    for (const action of ['select', 'reload-manifest']) {
+    for (const action of ['select', 'refresh-mesh']) {
       this.bindAction(action, () => {
         this.mouseState.updateUnconditionally();
         this.layerManager.invokeAction(action);

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -660,7 +660,7 @@ export class Viewer extends RefCounted implements ViewerState {
       });
     }
 
-    for (const action of ['select']) {
+    for (const action of ['select', 'reload-manifest']) {
       this.bindAction(action, () => {
         this.mouseState.updateUnconditionally();
         this.layerManager.invokeAction(action);


### PR DESCRIPTION
Adds a new shortcut to trigger mesh manifest call and re-render mesh after a merge/split.
This helps avoid refreshing the page to check the new mesh.

`Ctrl+Shift+mousedown0` on an active segment in 2D/3D views to trigger the action.