### PR TITLE
better design to display messges with Promises of any type

### DIFF
--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -256,6 +256,7 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
     status.setText(options.initialMessage);
     const dispose = status.dispose.bind(status);
     let response = await promise;
+    // TODO handle Promises of any type
     if (response !== undefined && !(response instanceof Response)) {
       response = new Response(response);
     }


### PR DESCRIPTION
Currently chunkedgraph layer only supports `Response<Response>` for making HTTP calls
Some functionality needs to use promises of any types (eg: getting a promise from a worker via rpc)