### PR TITLE
fix(save_state): restore compatibility with python state server

### DIFF
--- a/src/neuroglancer/save_state/save_state.ts
+++ b/src/neuroglancer/save_state/save_state.ts
@@ -196,7 +196,7 @@ export class SaveState extends RefCounted {
 
     this.key = getRandomHexString();
     params.set('local_id', this.key);
-    history.pushState({}, '', `${window.location.origin}/?${params.toString()}`);
+    history.pushState({}, '', `${window.location.origin}${window.location.pathname}?${params.toString()}`);
   }
   private reassign(master: any) {
     const hist = <string[]>master.history;


### PR DESCRIPTION
This PR restores communication between Neuroglancer and python state server. Python state server links have an additional path (e.g. `/v/f6ab55bea753e35d7d518c5da22b40a78532047e`), which was ignored during the local ID generation.