### PR TITLE
disable undo/redo when making edits

### DIFF
--- a/src/neuroglancer/differ/differ.ts
+++ b/src/neuroglancer/differ/differ.ts
@@ -29,20 +29,6 @@ export class Differ {
     const newSerial = this.legacy ? newState : JSON.stringify(newState);
     const stateChange = oldSerial !== newSerial;
 
-    /*if (newState.layers) {
-      // This effectively disables undo/redo if multicut points are selected
-      const graphOpMarker = newState.layers.find((layer: {[x: string]: any[];}) => {
-        if (layer.graphOperationMarker) {
-          return layer.graphOperationMarker.find(
-              ops => ops.annotations ? ops.annotations.length : false);
-        }
-      });
-      if (graphOpMarker) {
-        this.purgeHistory();
-        return true;
-      }
-    }*/
-
     if (stateChange) {
       const patch = diff.patch_toText(diff.patch_make(oldSerial, newSerial));
       const timestamp = (new Date()).valueOf();

--- a/src/neuroglancer/segmentation_user_layer.ts
+++ b/src/neuroglancer/segmentation_user_layer.ts
@@ -26,21 +26,21 @@ import {getRenderMeshByDefault} from 'neuroglancer/preferences/user_preferences'
 import {RenderScaleHistogram, trackableRenderScaleTarget} from 'neuroglancer/render_scale_statistics';
 import {SegmentColorHash} from 'neuroglancer/segment_color';
 import {SegmentMetadata, SegmentToVoxelCountMap} from 'neuroglancer/segment_metadata';
-import {SegmentSelectionState, Uint64MapEntry, SegmentationDisplayState3D} from 'neuroglancer/segmentation_display_state/frontend';
+import {SegmentationDisplayState3D, SegmentSelectionState, Uint64MapEntry} from 'neuroglancer/segmentation_display_state/frontend';
 import {SharedDisjointUint64Sets} from 'neuroglancer/shared_disjoint_sets';
-import {FRAGMENT_MAIN_START as SKELETON_FRAGMENT_MAIN_START, PerspectiveViewSkeletonLayer, SkeletonLayer, SkeletonRenderingOptions, SkeletonSource, SliceViewPanelSkeletonLayer, ViewSpecificSkeletonRenderingOptions, SkeletonLayerDisplayState} from 'neuroglancer/skeleton/frontend';
+import {FRAGMENT_MAIN_START as SKELETON_FRAGMENT_MAIN_START, PerspectiveViewSkeletonLayer, SkeletonLayer, SkeletonLayerDisplayState, SkeletonRenderingOptions, SkeletonSource, SliceViewPanelSkeletonLayer, ViewSpecificSkeletonRenderingOptions} from 'neuroglancer/skeleton/frontend';
 import {VolumeType} from 'neuroglancer/sliceview/volume/base';
 import {SegmentationRenderLayer, SliceViewSegmentationDisplayState} from 'neuroglancer/sliceview/volume/segmentation_renderlayer';
 import {StatusMessage} from 'neuroglancer/status';
 import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {ElementVisibilityFromTrackableBoolean, TrackableBoolean, TrackableBooleanCheckbox} from 'neuroglancer/trackable_boolean';
 import {ComputedWatchableValue} from 'neuroglancer/trackable_value';
-import {Uint64Set} from 'neuroglancer/uint64_set';
 import {Uint64Map} from 'neuroglancer/uint64_map';
+import {Uint64Set} from 'neuroglancer/uint64_set';
 import {UserLayerWithVolumeSourceMixin} from 'neuroglancer/user_layer_with_volume_source';
-import {parseRGBColorSpecification, packColor} from 'neuroglancer/util/color';
+import {packColor, parseRGBColorSpecification} from 'neuroglancer/util/color';
 import {Borrowed} from 'neuroglancer/util/disposable';
-import {parseArray, verifyObjectProperty, verifyOptionalString, verifyObjectAsMap} from 'neuroglancer/util/json';
+import {parseArray, verifyObjectAsMap, verifyObjectProperty, verifyOptionalString} from 'neuroglancer/util/json';
 import {NullarySignal} from 'neuroglancer/util/signal';
 import {Uint64} from 'neuroglancer/util/uint64';
 import {makeWatchableShaderError} from 'neuroglancer/webgl/dynamic_shader';
@@ -314,7 +314,8 @@ export class SegmentationUserLayer extends Base {
               }
             });
           }
-          if (skeletonsPath === undefined && volume.getSkeletonSource && this.shouldRenderSkeletons()) {
+          if (skeletonsPath === undefined && volume.getSkeletonSource &&
+              this.shouldRenderSkeletons()) {
             ++remaining;
             Promise.resolve(volume.getSkeletonSource()).then(skeletonSource => {
               if (this.wasDisposed) {
@@ -355,11 +356,11 @@ export class SegmentationUserLayer extends Base {
     }
   }
 
-  private shouldRenderMesh() : boolean {
+  private shouldRenderMesh(): boolean {
     return getRenderMeshByDefault() && this.loadMeshes.value;
   }
 
-  private shouldRenderSkeletons() : boolean {
+  private shouldRenderSkeletons(): boolean {
     return this.loadSkeletons.value;
   }
 
@@ -401,7 +402,8 @@ export class SegmentationUserLayer extends Base {
     if (segmentStatedColors.size > 0) {
       let json = segmentStatedColors.toJSON();
       // Convert colors from decimal integers to CSS "#RRGGBB" format.
-      Object.keys(json).map(k => json[k] = '#' + parseInt(json[k], 10).toString(16).padStart(6, '0'));
+      Object.keys(json).map(
+          k => json[k] = '#' + parseInt(json[k], 10).toString(16).padStart(6, '0'));
       x[SEGMENT_STATED_COLORS_JSON_KEY] = json;
     }
     let {rootSegments} = this.displayState;
@@ -460,6 +462,13 @@ export class SegmentationUserLayer extends Base {
     if (this.ignoreSegmentInteractions.value) {
       return;
     }
+    // TODO: Merge unsupported with edits
+    const disposeUndoRedoAfterEdit = () => {
+      const view = (<any>window)['viewer'];
+      view.deactivateEditMode();
+      view.differ.purgeHistory();
+      view.differ.ignoreChanges();
+    };
     switch (action) {
       case 'recolor': {
         this.displayState.segmentColorHash.randomize();
@@ -481,6 +490,7 @@ export class SegmentationUserLayer extends Base {
         // Cleanup by removing all old root segments
         const newRootSegment = segmentEquivalences.get(firstSegment);
         rootSegments.delete([...rootSegments].filter(id => !Uint64.equal(id, newRootSegment)));
+        disposeUndoRedoAfterEdit();
         break;
       }
       case 'cut-selected': {
@@ -490,6 +500,7 @@ export class SegmentationUserLayer extends Base {
           segmentEquivalences.deleteSet(rootSegment);
           rootSegments.add(segments.filter(id => !Uint64.equal(id, rootSegment)));
         }
+        disposeUndoRedoAfterEdit();
         break;
       }
       case 'select': {
@@ -506,6 +517,7 @@ export class SegmentationUserLayer extends Base {
       }
       case 'merge-select-second': {
         this.mergeSelectSecond();
+        disposeUndoRedoAfterEdit();
         break;
       }
       case 'split-select-first': {
@@ -701,26 +713,22 @@ class DisplayOptionsTab extends Tab {
     group3D.appendFixedChild(this.objectAlphaWidget.element);
 
     {
-      const checkbox =
-          this.registerDisposer(new TrackableBooleanCheckbox(layer.loadMeshes));
+      const checkbox = this.registerDisposer(new TrackableBooleanCheckbox(layer.loadMeshes));
       checkbox.element.className =
           'neuroglancer-segmentation-dropdown-load-meshes neuroglancer-noselect';
       const label = document.createElement('label');
-      label.className =
-          'neuroglancer-segmentation-dropdown-load-meshes neuroglancer-noselect';
+      label.className = 'neuroglancer-segmentation-dropdown-load-meshes neuroglancer-noselect';
       label.appendChild(document.createTextNode('Load layer meshes (requires refresh)'));
       label.appendChild(checkbox.element);
       group3D.appendFixedChild(label);
     }
 
     {
-      const checkbox =
-          this.registerDisposer(new TrackableBooleanCheckbox(layer.loadSkeletons));
+      const checkbox = this.registerDisposer(new TrackableBooleanCheckbox(layer.loadSkeletons));
       checkbox.element.className =
           'neuroglancer-segmentation-dropdown-load-skeletons neuroglancer-noselect';
       const label = document.createElement('label');
-      label.className =
-          'neuroglancer-segmentation-dropdown-load-skeletons neuroglancer-noselect';
+      label.className = 'neuroglancer-segmentation-dropdown-load-skeletons neuroglancer-noselect';
       label.appendChild(document.createTextNode('Load layer skeletons (requires refresh)'));
       label.appendChild(checkbox.element);
       group3D.appendFixedChild(label);

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -348,13 +348,18 @@ export class GraphOperationLayerView extends Tab {
           if (splitRoots.length === 0) {
             StatusMessage.showTemporaryMessage(`No split found.`, 3000);
           } else {
-            let segmentationState = this.annotationLayer.segmentationState.value!
+            let segmentationState = this.annotationLayer.segmentationState.value!;
             for (let segment of [...sinks, ...sources]) {
               segmentationState.rootSegments.delete(segment.rootId);
             }
             segmentationState.rootSegmentsAfterEdit!.clear();
             segmentationState.rootSegments.add(splitRoots);
             segmentationState.rootSegmentsAfterEdit!.add(splitRoots);
+
+            // TODO: Merge unsupported with edits
+            const view = (<any>window)['viewer'];
+            view.differ.purgeHistory();
+            view.differ.ignoreChanges();
           }
         });
       });

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -730,16 +730,20 @@ export class Viewer extends RefCounted implements ViewerState {
       const splitOn = () => StatusMessage.showTemporaryMessage('Split mode activated.');
       const mergeOff = () => StatusMessage.showTemporaryMessage('Merge mode deactivated.');
       const splitOff = () => StatusMessage.showTemporaryMessage('Split mode deactivated.');
+      const disable = (deactivate = true) => this.differ.disable = deactivate;
+      this.differ.purgeHistory();
 
       if (mergeWhileInSplit) {
         this.mouseState.setMode(ActionMode.MERGE);
         mergeOn();
         splitOff();
+        disable();
         this.mouseState.toggleAction();
       } else if (splitWhileInMerge) {
         this.mouseState.setMode(ActionMode.SPLIT);
         splitOn();
         mergeOff();
+        disable();
         this.mouseState.toggleAction();
       } else if (this.mouseState.actionState === ActionState.INACTIVE) {
         if (this.mouseState.actionMode === ActionMode.MERGE) {
@@ -747,6 +751,7 @@ export class Viewer extends RefCounted implements ViewerState {
         } else {
           splitOff();
         }
+        disable(false);
         this.mouseState.setMode(ActionMode.NONE);
       } else {
         if (merge) {
@@ -756,6 +761,7 @@ export class Viewer extends RefCounted implements ViewerState {
           this.mouseState.setMode(ActionMode.SPLIT);
           splitOn();
         }
+        disable();
       }
     };
 


### PR DESCRIPTION
Undo/Redo has erroneous behavior when state changes include an edit. This patch temporarily disables undo/redo in merge or split mode and when making a multicut. Additionally, undo/redo history before an edit is made is discarded to prevent returning to an outdated state.