### PR TITLE
Show save dialog when no state server

### DIFF
--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -1006,7 +1006,12 @@ export class Viewer extends RefCounted implements ViewerState {
               errorPrefix: ''
             });
       } else {
-        StatusMessage.showTemporaryMessage(`No state server found.`, 4000, {color: 'yellow'});
+        if (getUrlType === UrlType.json) {
+          StatusMessage.showTemporaryMessage(`No state server found.`, 4000, {color: 'yellow'});
+          this.showSaveDialog();
+        } else {
+          this.showSaveDialog(getUrlType);
+        }
       }
     } else {
       if (savestate) {


### PR DESCRIPTION
Addresses #552 by showing the save dialog when the user attempts the `save-state-getjson` shortcut when there is no state server for the session. Also fixes a bug where if you request to copy the raw url via the `save-state-getraw` shortcut without a state server in the session, neuroglancer does not and tells the user there is no state server.