### PR TITLE
feat: Enable matrix protocol for cloudian

### DIFF
--- a/src/neuroglancer/util/http_request.ts
+++ b/src/neuroglancer/util/http_request.ts
@@ -134,6 +134,11 @@ export function parseSpecialUrl(url: string): string {
     let path = match[3];
     if (path === undefined) path = '';
     return `https://s3.amazonaws.com/${bucket}${path}`;
+  } else if (protocol === 'matrix') {
+    const bucket = match[2];
+    let path = match[3];
+    if (path === undefined) path = '';
+    return `https://seungdata.princeton.edu/${bucket}${path}`;
   }
   return url;
 }


### PR DESCRIPTION
Currently needed for graphene layers to retrieve cloudian data, as the ChunkedGraph returns matrix paths to Neuroglancer.