### PR TITLE
Fix: find path in 2D

### DIFF
--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -227,8 +227,8 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
         authFetch(`${url}/graph/find_path?int64_as_str=1&precision_mode=${Number(precisionMode)}`, {
           method: 'POST',
           body: JSON.stringify([
-            [String(first.segmentId), ...first.position.values()],
-            [String(second.segmentId), ...second.position.values()]
+            [String(first.rootId), ...first.position.values()],
+            [String(second.rootId), ...second.position.values()]
           ])
         });
 


### PR DESCRIPTION
Find path tool currently sends supervoxel ids when points are selected in 2D which the ChunkedGraph does not expect. Neuroglancer should send root ids instead.