### PR TITLE
Feat: shortcut for multicut to improve usability

### DIFF
--- a/src/neuroglancer/graph/graph_operation_layer_state.ts
+++ b/src/neuroglancer/graph/graph_operation_layer_state.ts
@@ -181,6 +181,7 @@ export class GraphOperationLayerState extends RefCounted {
       this.annotationToSupervoxelA.isActive.value = true;
       this.annotationToSupervoxelB.isActive.value = false;
     }
+    this.changed.dispatch();
   }
 
   getReference(id: AnnotationId): AnnotationReference {

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -31,7 +31,7 @@ import {StatusMessage} from 'neuroglancer/status';
 import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
 import {TrackableValue, WatchableRefCounted, WatchableValue} from 'neuroglancer/trackable_value';
-import {GraphOperationTab, SelectedGraphOperationState} from 'neuroglancer/ui/graph_multicut';
+import {enableSplitPointTool, GraphOperationTab, PlaceGraphOperationMarkerTool, SelectedGraphOperationState} from 'neuroglancer/ui/graph_multicut';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {TrackableRGB} from 'neuroglancer/util/color';
 import {Borrowed, RefCounted} from 'neuroglancer/util/disposable';
@@ -322,7 +322,12 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
           break;
         }
         case 'switch-multicut-group': {
-          this.graphOperationLayerState.value!.toggleSource();
+          if (this.tool.value === undefined ||
+              (!(this.tool.value instanceof PlaceGraphOperationMarkerTool))) {
+            enableSplitPointTool(this, this.graphOperationLayerState.value!);
+          } else {
+            this.graphOperationLayerState.value!.toggleSource();
+          }
           break;
         }
         default:

--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -321,6 +321,10 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
           this.reloadManifest();
           break;
         }
+        case 'switch-multicut-group': {
+          this.graphOperationLayerState.value!.toggleSource();
+          break;
+        }
         default:
           super.handleAction(action);
           break;

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -83,6 +83,7 @@ export function getDefaultRenderedDataPanelBindings() {
           'keyc': 'two-point-cut',
           'control+keyc': 'cut-selected',
           'control+keys': 'shatter-segment-equivalences',
+          'control+shift+backslash': 'switch-multicut-group',
           'at:control+wheel': {action: 'zoom-via-wheel', preventDefault: true},
           'at:wheel': {action: 'z+1-via-wheel', preventDefault: true},
           'at:shift+wheel': {action: 'z+10-via-wheel', preventDefault: true},

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -46,6 +46,7 @@ export function getDefaultGlobalBindings() {
     map.set('space', 'toggle-layout');
     map.set('shift+space', 'toggle-layout-alternative');
     map.set('backslash', 'toggle-show-statistics');
+    map.set('control+shift+backslash', 'switch-multicut-group');
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;
@@ -83,7 +84,6 @@ export function getDefaultRenderedDataPanelBindings() {
           'keyc': 'two-point-cut',
           'control+keyc': 'cut-selected',
           'control+keys': 'shatter-segment-equivalences',
-          'control+shift+backslash': 'switch-multicut-group',
           'at:control+wheel': {action: 'zoom-via-wheel', preventDefault: true},
           'at:wheel': {action: 'z+1-via-wheel', preventDefault: true},
           'at:shift+wheel': {action: 'z+10-via-wheel', preventDefault: true},

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -278,6 +278,26 @@ function getCenterPosition(annotation: Annotation, transform: mat4) {
   return vec3.transformMat4(center, center, transform);
 }
 
+export function enableSplitPointTool(
+    layer: SegmentationUserLayerWithGraph, graphOperationLayerState: GraphOperationLayerState) {
+  layer.tool.value = new PlaceGraphOperationMarkerTool(
+      layer, {},
+      () => {
+        if (graphOperationLayerState.activeSource === graphOperationLayerState.sourceA) {
+          return 'set graph red split point';
+        } else {
+          return 'set graph blue split point';
+        }
+      },
+      () => {
+        if (graphOperationLayerState.activeSource === graphOperationLayerState.sourceA) {
+          return 'rgb(255,0,0)';
+        } else {
+          return 'rgb(120,120,255)';
+        }
+      });
+}
+
 export class GraphOperationLayerView extends Tab {
   private annotationListContainer = document.createElement('ul');
   private annotationListElements = new Map<string, HTMLElement>();
@@ -319,24 +339,7 @@ export class GraphOperationLayerView extends Tab {
       const pointButton = document.createElement('button');
       pointButton.textContent = getAnnotationTypeHandler(AnnotationType.POINT).icon;
       pointButton.title = 'Set split point';
-      pointButton.addEventListener('click', () => {
-        this.wrapper.tool.value = new PlaceGraphOperationMarkerTool(
-            this.wrapper, {},
-            () => {
-              if (this.annotationLayer.activeSource === sourceA) {
-                return 'set graph red split point';
-              } else {
-                return 'set graph blue split point';
-              }
-            },
-            () => {
-              if (this.annotationLayer.activeSource === sourceA) {
-                return 'rgb(255,0,0)';
-              } else {
-                return 'rgb(120,120,255)';
-              }
-            });
-      });
+      pointButton.addEventListener('click', enableSplitPointTool.bind(undefined, this.wrapper, this.annotationLayer));
       toolbox.appendChild(pointButton);
     }
 

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -320,7 +320,22 @@ export class GraphOperationLayerView extends Tab {
       pointButton.textContent = getAnnotationTypeHandler(AnnotationType.POINT).icon;
       pointButton.title = 'Set split point';
       pointButton.addEventListener('click', () => {
-        this.wrapper.tool.value = new PlaceGraphOperationMarkerTool(this.wrapper, {});
+        this.wrapper.tool.value = new PlaceGraphOperationMarkerTool(
+            this.wrapper, {},
+            () => {
+              if (this.annotationLayer.activeSource === sourceA) {
+                return 'set graph red split point';
+              } else {
+                return 'set graph blue split point';
+              }
+            },
+            () => {
+              if (this.annotationLayer.activeSource === sourceA) {
+                return 'rgb(255,0,0)';
+              } else {
+                return 'rgb(120,120,255)';
+              }
+            });
       });
       toolbox.appendChild(pointButton);
     }
@@ -979,8 +994,14 @@ abstract class PlaceGraphOperationTool extends Tool {
 }
 
 export class PlaceGraphOperationMarkerTool extends PlaceGraphOperationTool {
-  constructor(layer: SegmentationUserLayerWithGraph, options: any) {
+  private _getDescription: () => string;
+
+  constructor(
+      layer: SegmentationUserLayerWithGraph, options: any, getDescription: () => string,
+      getDescriptionColor: () => string) {
     super(layer, options);
+    this._getDescription = getDescription;
+    this.getDescriptionColor = getDescriptionColor;
   }
 
   trigger(mouseState: MouseSelectionState) {
@@ -1039,7 +1060,7 @@ export class PlaceGraphOperationMarkerTool extends PlaceGraphOperationTool {
   }
 
   get description() {
-    return `set graph merge/split point`;
+    return this._getDescription();
   }
 
   toJSON() {

--- a/src/neuroglancer/ui/tool.ts
+++ b/src/neuroglancer/ui/tool.ts
@@ -28,6 +28,7 @@ export abstract class Tool extends RefCounted {
   abstract toJSON(): any;
   deactivate(): void {}
   description: string;
+  getDescriptionColor?(): string;
 }
 
 export function restoreTool(layer: UserLayer, obj: any) {

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -762,7 +762,7 @@ export class Viewer extends RefCounted implements ViewerState {
   private registerActionListeners() {
     for (const action
              of ['recolor', 'clear-segments', 'merge-selected', 'cut-selected',
-                 'shatter-segment-equivalences']) {
+                 'shatter-segment-equivalences', 'switch-multicut-group']) {
       this.bindAction(action, () => {
         this.layerManager.invokeAction(action);
       });

--- a/src/neuroglancer/widget/annotation_tool_status.ts
+++ b/src/neuroglancer/widget/annotation_tool_status.ts
@@ -69,7 +69,25 @@ export class AnnotationToolStatusWidget extends RefCounted {
     return tool.description;
   }
 
+  private getDescriptionColor(): string {
+    const defaultColor = '#33cc33';
+    const layer = this.selectedLayer.layer;
+    if (layer === undefined) {
+      return defaultColor;
+    }
+    const userLayer = layer.layer;
+    if (userLayer === null) {
+      return defaultColor;
+    }
+    const tool = userLayer.tool.value;
+    if (tool === undefined || tool.getDescriptionColor === undefined) {
+      return defaultColor;
+    }
+    return tool.getDescriptionColor();
+  }
+
   private updateView() {
     this.element.textContent = this.getDescriptionText() || '';
+    this.element.style.color = this.getDescriptionColor();
   }
 }


### PR DESCRIPTION
This PR addresses issues #537 and #519 by introducing ctrl+shift+backslash as a way to enable the multicut tool or to switch between multicut groups. Currently the only way of doing so is to manually go to the Rendering tab of a graphene layer, and click on the relevant buttons. The PR also changes the tool description in the top right to show users which group is currently active, and changes the description color depending on the group for more visibility.