### PR TITLE
fix: prevent Neuroglancer from stealing focus when it is embedded in …

### DIFF
--- a/src/neuroglancer/util/automatic_focus.ts
+++ b/src/neuroglancer/util/automatic_focus.ts
@@ -29,7 +29,10 @@ class AutomaticFocusList {
 
 const automaticFocusList = new AutomaticFocusList();
 
+const isTopLevel = window.top === window;
+
 const maybeUpdateFocus = debounce(() => {
+  if (!isTopLevel) return;
   const {activeElement} = document;
   if (activeElement === null || activeElement === document.body) {
     const node = LinkedListOperations.front<AutomaticallyFocusedElement>(<any>automaticFocusList);


### PR DESCRIPTION
…an iframe

This allows Neuroglancer to be embedded as an iframe in a Jupyter notebook.