### PR TITLE
Neuvue Feat: Multicut and Mesh Opacity Hotkeys

### DIFF
--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -330,12 +330,30 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
           }
           break;
         }
+        case 'decrease-segmentation-opacity': {
+          this.changeOnOpacity('decrease');
+          break;
+        }
+        case 'increase-segmentation-opacity': {
+          this.changeOnOpacity('increase');
+          break;
+        }
         default:
           super.handleAction(action);
           break;
       }
     }
 
+    changeOnOpacity(direction: string) {
+      // function that changes opacity by 10%
+      if (direction === "decrease") {
+        this.displayState.objectAlpha.value = Math.round(Math.max(0, this.displayState.objectAlpha.value - 0.1)*10)/10;
+      } 
+
+      else if (direction === "increase") {
+        this.displayState.objectAlpha.value = Math.round(Math.min(1, this.displayState.objectAlpha.value + 0.1)*10)/10;
+      } 
+    }
     getRootOfSelectedSupervoxel() {
       let {segmentSelectionState, timestamp} = this.displayState;
       let tsValue = (timestamp.value !== '') ? timestamp.value : void (0);

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -47,6 +47,8 @@ export function getDefaultGlobalBindings() {
     map.set('shift+space', 'toggle-layout-alternative');
     map.set('backslash', 'toggle-show-statistics');
     map.set('keyg', 'switch-multicut-group');
+    map.set('keyi', 'decrease-segmentation-opacity');
+    map.set('keyu', 'increase-segmentation-opacity');
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -46,7 +46,7 @@ export function getDefaultGlobalBindings() {
     map.set('space', 'toggle-layout');
     map.set('shift+space', 'toggle-layout-alternative');
     map.set('backslash', 'toggle-show-statistics');
-    map.set('control+shift+backslash', 'switch-multicut-group');
+    map.set('keyg', 'switch-multicut-group');
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -762,7 +762,8 @@ export class Viewer extends RefCounted implements ViewerState {
   private registerActionListeners() {
     for (const action
              of ['recolor', 'clear-segments', 'merge-selected', 'cut-selected',
-                 'shatter-segment-equivalences', 'switch-multicut-group']) {
+                 'shatter-segment-equivalences', 'switch-multicut-group', 
+                 'decrease-segmentation-opacity', 'increase-segmentation-opacity']) {
       this.bindAction(action, () => {
         this.layerManager.invokeAction(action);
       });


### PR DESCRIPTION
This PR changes the `switch-multi-group` hotkey to `g` and adds two new hotkeys for increase and decreasing segmentation opacity by 10% to `i` and `u`, respectively. 

