### PR TITLE
Neuvue Feat: Allow path to be regenerated with new root IDs

### DIFF
--- a/src/neuroglancer/graph/path_finder_state.ts
+++ b/src/neuroglancer/graph/path_finder_state.ts
@@ -175,6 +175,35 @@ class PathBetweenSupervoxels extends RefCounted {
     this.changed.dispatch();
   }
 
+  getLatestSegments(layer: SegmentationUserLayerWithGraph) {
+    if (!this._source || !this._target){
+      return
+    }
+    const {segmentSelectionState} = layer.displayState;
+    const newSource: Point = {
+      id: '',
+      segments: [
+        segmentSelectionState.rawSelectedSegment.clone(),
+        segmentSelectionState.selectedSegment.clone()
+      ],
+      point: this._source.point,
+      type: AnnotationType.POINT,
+    };
+
+    const newTarget: Point = {
+      id: '',
+      segments: [
+        segmentSelectionState.rawSelectedSegment.clone(),
+        segmentSelectionState.selectedSegment.clone()
+      ],
+      point: this._target.point,
+      type: AnnotationType.POINT,
+    };
+    this.clear();
+    this.addSourceOrTarget(newSource);
+    this.addSourceOrTarget(newTarget);
+  }
+
   toJSON() {
     const x: any = {
       [ANNOTATION_PATH_JSON_KEY]: this.annotationSource.toJSON(),


### PR DESCRIPTION
If a path already exists, and the user clicks "Generate Path", the `getLatestSegments()` function will reset the source and target points to have the latest root IDs and attempt to regenerate the path. 

This also sets the path finding precision mode to be checked by default.