### PR TITLE
Neuvue Feat: Adds new hotkey for removing status messages

### DIFF
--- a/src/neuroglancer/sliceview/chunked_graph/frontend.ts
+++ b/src/neuroglancer/sliceview/chunked_graph/frontend.ts
@@ -284,8 +284,8 @@ export class ChunkedGraphLayer extends GenericSliceViewRenderLayer {
       this.leafRequestsStatusMessage = undefined;
       StatusMessage.showTemporaryMessage('Loading chunked graph segmentation...', 3000);
     } else if ((!this.leafRequestsStatusMessage) && (!leafRequestsActive)) {
-      this.leafRequestsStatusMessage = StatusMessage.showMessage(
-          'At this zoom level, chunked graph segmentation will not be loaded. Please zoom in if you wish to load it.');
+      this.leafRequestsStatusMessage = StatusMessage.showTemporaryMessage(
+        'At this zoom level, chunked graph segmentation will not be loaded. Please zoom in if you wish to load it.', 3000);
     }
   }
 }

--- a/src/neuroglancer/status.ts
+++ b/src/neuroglancer/status.ts
@@ -151,4 +151,12 @@ export class StatusMessage {
   }): StatusMessage {
     return this.showTemporaryMessage(message, closeAfter, config);
   }
+
+  static disposeAll() {
+    if (statusContainer !== null) {
+      while (statusContainer.firstChild) {
+        statusContainer.removeChild(statusContainer.firstChild);
+      }
+    }
+  }
 }

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -47,6 +47,7 @@ export function getDefaultGlobalBindings() {
     map.set('shift+space', 'toggle-layout-alternative');
     map.set('backslash', 'toggle-show-statistics');
     map.set('control+shift+backslash', 'switch-multicut-group');
+    map.set('keyx', 'dismiss-all-status-messages');
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -784,7 +784,8 @@ export class Viewer extends RefCounted implements ViewerState {
     });
 
     this.bindAction('help', () => this.showHelpDialog());
-
+    this.bindAction('dismiss-all-status-messages', () => StatusMessage.disposeAll() )
+    
     for (let i = 1; i <= 9; ++i) {
       this.bindAction(`toggle-layer-${i}`, () => {
         const layerIndex = i - 1;
@@ -1109,8 +1110,8 @@ export class Viewer extends RefCounted implements ViewerState {
       }
       hashBinding.parseError;
     }));
-    StatusMessage.showTemporaryMessage(
-        `RAW URLs will soon be Deprecated. Please use JSON URLs whenever available.`, 10000);
+    // StatusMessage.showTemporaryMessage(
+    //     `RAW URLs will soon be Deprecated. Please use JSON URLs whenever available.`, 10000);
     hashBinding.updateFromUrlHash();
 
     return hashBinding;


### PR DESCRIPTION
Proofreader feedback noted that status messages from zooming in and out of the data, merging and splitting were getting in the way, so we added this feature to allow proofreaders to clear status messages and reduce the amount of repeated status messages.